### PR TITLE
Semantically enrich grassland crops

### DIFF
--- a/rdf/cultivationtypes.ttl
+++ b/rdf/cultivationtypes.ttl
@@ -1342,7 +1342,7 @@ cultivationtype:702 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:5 .
+    :partOf cultivationtype:730 .
 
 cultivationtype:703 a :CultivationType ;
     schema:name "Obstanlagen (Birnen)"@de,
@@ -1352,7 +1352,7 @@ cultivationtype:703 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:5 .
+    :partOf cultivationtype:730 .
 
 cultivationtype:704 a :CultivationType ;
     schema:name "Obstanlagen (Steinobst)"@de,
@@ -1362,7 +1362,7 @@ cultivationtype:704 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:5 .
+    :partOf cultivationtype:730 .
 
 cultivationtype:705 a :CultivationType ;
     schema:name "Mehrjährige Beeren"@de,
@@ -1372,7 +1372,7 @@ cultivationtype:705 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:706 a :CultivationType ;
     schema:name "Mehrjährige Gewürz- und Medizinalpflanzen"@de,
@@ -1382,7 +1382,7 @@ cultivationtype:706 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:707 a :CultivationType ;
     schema:name "Mehrjährige nachwachsende Rohstoffe (Chinaschilf, usw.)"@de,
@@ -1392,7 +1392,7 @@ cultivationtype:707 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:708 a :CultivationType ;
     schema:name "Hopfen"@de,
@@ -1402,7 +1402,7 @@ cultivationtype:708 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:709 a :CultivationType ;
     schema:name "Rhabarber"@de,
@@ -1412,7 +1412,7 @@ cultivationtype:709 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:710 a :CultivationType ;
     schema:name "Spargel"@de,
@@ -1422,7 +1422,7 @@ cultivationtype:710 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:711 a :CultivationType ;
     schema:name "Pilze (Freiland)"@de,
@@ -1432,7 +1432,7 @@ cultivationtype:711 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:712 a :CultivationType ;
     schema:name "Christbäume"@de,
@@ -1442,7 +1442,7 @@ cultivationtype:712 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:713 a :CultivationType ;
     schema:name "Baumschule von Forstpflanzen ausserhalb der Forstzone"@de,
@@ -1452,7 +1452,7 @@ cultivationtype:713 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:714 a :CultivationType ;
     schema:name "Ziersträucher, Ziergehölze und Zierstauden"@de,
@@ -1462,7 +1462,7 @@ cultivationtype:714 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:715 a :CultivationType ;
     schema:name "Übrige Baumschulen (Rosen, Früchte, usw.)"@de,
@@ -1493,7 +1493,7 @@ cultivationtype:718 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2014-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:719 a :CultivationType ;
     schema:name "Maulbeerbaumanlagen (Fütterung Seidenraupen)"@de,
@@ -1503,7 +1503,7 @@ cultivationtype:719 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2014-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:720 a :CultivationType ;
     schema:name "Gepflegte Selven (Edelkastanienbäume)"@de,
@@ -1513,7 +1513,7 @@ cultivationtype:720 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2014-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:721 a :CultivationType ;
     schema:name "Mehrjährige gärtnerische Freilandkulturen (nicht im Gewächshaus)"@de,
@@ -1523,7 +1523,7 @@ cultivationtype:721 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2015-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:722 a :CultivationType ;
     schema:name "Baumschulen von Reben"@de,
@@ -1533,7 +1533,7 @@ cultivationtype:722 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2016-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:723 a :CultivationType ;
     schema:name "Baumschulen von Obst und Beeren"@de,
@@ -1543,7 +1543,7 @@ cultivationtype:723 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2023-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:724 a :CultivationType ;
     schema:name "Übrige Baumschulen (Rosen, Zierstauden, usw.)"@de,
@@ -1553,9 +1553,10 @@ cultivationtype:724 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2023-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:725 a :CultivationType ;
+    schema:description "Kleinräumige Mischung verschiedener Kulturen mit mehr als 50% Spezialkulturen."@de ;
     schema:name "Permakultur"@de,
         "Permaculture"@fr,
         "Permacultura"@it ;
@@ -1563,7 +1564,7 @@ cultivationtype:725 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2020-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:730 a :CultivationType ;
     schema:name "Obstanlagen aggregiert"@de,
@@ -1583,7 +1584,7 @@ cultivationtype:731 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2009-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:5 .
+    :partOf cultivationtype:730 .
 
 cultivationtype:735 a :CultivationType ;
     schema:name "Reben (regionsspezifische Biodiversitätsförderflächen)"@de,
@@ -1624,7 +1625,7 @@ cultivationtype:797 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:6 .
+    :partOf cultivationtype:750 .
 
 cultivationtype:798 a :CultivationType ;
     schema:name "Übrige Flächen mit Dauerkulturen, nicht beitragsberechtigt"@de,
@@ -1652,7 +1653,7 @@ cultivationtype:801 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:802 a :CultivationType ;
     schema:name "Übrige Spezialkulturen in Gewächshäusern mit festem Fundament"@de,
@@ -1662,7 +1663,7 @@ cultivationtype:802 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:803 a :CultivationType ;
     schema:name "Gärtnerische Kulturen in Gewächshäusern mit festem Fundament"@de,
@@ -1672,7 +1673,7 @@ cultivationtype:803 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:804 a :CultivationType ;
     schema:name "Beerenkulturen in Gewächshäusern mit festem Fundament"@de,
@@ -1682,7 +1683,7 @@ cultivationtype:804 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2023-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:806 a :CultivationType ;
     schema:name "Gemüsekulturen in geschütztem Anbau ohne festes Fundament"@de,
@@ -1693,7 +1694,7 @@ cultivationtype:806 a :CultivationType ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             schema:validTo "2022-12-31"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:807 a :CultivationType ;
     schema:name "Übrige Spezialkulturen in geschütztem Anbau ohne festes Fundament"@de,
@@ -1703,7 +1704,7 @@ cultivationtype:807 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:808 a :CultivationType ;
     schema:name "Gärtnerische Kulturen in geschütztem Anbau ohne festes Fundament"@de,
@@ -1713,7 +1714,7 @@ cultivationtype:808 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:810 a :CultivationType ;
     schema:name "Pilze in geschütztem Anbau mit festem Fundament"@de,
@@ -1723,7 +1724,7 @@ cultivationtype:810 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2014-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:811 a :CultivationType ;
     schema:name "Gemüsekulturen in geschütztem Anbau ohne festes Fundament; im gewachsenen Boden"@de,
@@ -1733,7 +1734,7 @@ cultivationtype:811 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2023-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:812 a :CultivationType ;
     schema:name "Gemüsekulturen in geschütztem Anbau ohne festes Fundament; auf Pflanztischen oder -gestellen"@de,
@@ -1743,7 +1744,7 @@ cultivationtype:812 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2023-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:813 a :CultivationType ;
     schema:name "Beerenkulturen in geschütztem Anbau ohne festes Fundament; im gewachsenen Boden"@de,
@@ -1753,7 +1754,7 @@ cultivationtype:813 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2023-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:814 a :CultivationType ;
     schema:name "Beerenkulturen in geschütztem Anbau ohne festes Fundament; auf Pflanztischen oder -gestellen"@de,
@@ -1763,7 +1764,7 @@ cultivationtype:814 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "2023-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:830 a :CultivationType ;
     schema:name "Kulturen in ganzjährig geschütztem Anbau, beitragsberechtigt aggregiert"@de,
@@ -1794,7 +1795,7 @@ cultivationtype:847 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:848 a :CultivationType ;
     schema:name "Übrige Kulturen in geschütztem Anbau mit festem Fundament"@de,
@@ -1804,7 +1805,7 @@ cultivationtype:848 a :CultivationType ;
             schema:name "AGIS" ;
             schema:validFrom "1999-01-01"^^xsd:date ;
             :memberOfClass :DirectPaymentCrop ] ;
-    :partOf cultivationtype:7 .
+    :partOf cultivationtype:830 .
 
 cultivationtype:849 a :CultivationType ;
     schema:name "Übrige Kulturen in geschütztem Anbau ohne festes Fundament, nicht beitragsberechtigt"@de,


### PR DESCRIPTION
- Add new group "Dauergrünfläche", combining pasture and meadows. Descriptions are taken from LBV.
- Add new group "Heuwiesen" to create clearer structure.
- "Uferwiesen entlang von Fliessgewässern" is part of "Uferwiesen": This makes sense, since the latter replaced the first. Since the concepts are not used in AGIS at the same time, this doesn't create any hierarchy within AGIS concepts.
- Add intensity labels/attributes, where clearly available.
- Works on #23 
