### PR TITLE
Run pyshacl on PR

### DIFF
--- a/.github/workflows/graph-pipeline.yml
+++ b/.github/workflows/graph-pipeline.yml
@@ -36,7 +36,8 @@ jobs:
         run: pytest ${{ matrix.test-file }} -v
       
       - name: Validate data input files
-        run: pyshacl rdf/data/srppp.ttl --format human
-        run: pyshacl rdf/data/agis.ttl --format human
-        run: pyshacl rdf/data/naebi.ttl --format human
-        run: pyshacl rdf/ontology/cultivationtypes.ttl --format human
+        run: |
+          pyshacl rdf/data/srppp.ttl --format human
+          pyshacl rdf/data/agis.ttl --format human
+          pyshacl rdf/data/naebi.ttl --format human
+          pyshacl rdf/ontology/cultivationtypes.ttl --format human

--- a/.github/workflows/graph-pipeline.yml
+++ b/.github/workflows/graph-pipeline.yml
@@ -11,9 +11,8 @@ jobs:
     name: Run Pytests Individually
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # Prevents one failing test from cancelling the others
+      fail-fast: false
       matrix:
-        # Add test files to this array to run them in isolation
         test-file: 
           - tests/test_turtle_syntax.py
     
@@ -34,10 +33,32 @@ jobs:
 
       - name: Execute ${{ matrix.test-file }}
         run: pytest ${{ matrix.test-file }} -v
-      
-      - name: Validate data input files
+
+  validate:
+    name: Validate Data Input Files
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Prevents one invalid file from cancelling the checks on the others
+      matrix:
+        ttl-file:
+          - rdf/data/srppp.ttl
+          - rdf/data/agis.ttl
+          - rdf/data/naebi.ttl
+          - rdf/ontology/cultivationtypes.ttl
+          
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pyshacl
         run: |
-          pyshacl rdf/data/srppp.ttl --format human
-          pyshacl rdf/data/agis.ttl --format human
-          pyshacl rdf/data/naebi.ttl --format human
-          pyshacl rdf/ontology/cultivationtypes.ttl --format human
+          python -m pip install --upgrade pip
+          pip install pyshacl 
+
+      - name: Validate ${{ matrix.ttl-file }}
+        run: pyshacl ${{ matrix.ttl-file }} --format human

--- a/.github/workflows/graph-pipeline.yml
+++ b/.github/workflows/graph-pipeline.yml
@@ -37,3 +37,6 @@ jobs:
       
       - name: Validate data input files
         run: pyshacl rdf/data/srppp.ttl --format human
+        run: pyshacl rdf/data/agis.ttl --format human
+        run: pyshacl rdf/data/naebi.ttl --format human
+        run: pyshacl rdf/ontology/cultivationtypes.ttl --format human

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -40,20 +40,20 @@ cultivationtype:shape a sh:NodeShape ;
         sh:minCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:datatype rdf:langString ;
-        sh:languageIn ( "de" "fr" "it" ) ;
+        sh:languageIn ( "de" "fr" "it" "en" ) ;
         sh:uniqueLang true ;
     ],
     [
         sh:path schema:alternateName ;
         sh:nodeKind sh:Literal ;
         sh:datatype rdf:langString ;
-        sh:languageIn ( "de" "fr" "it" ) ;
+        sh:languageIn ( "de" "fr" "it" "en" ) ;
     ],
     [
         sh:path schema:description ;
         sh:nodeKind sh:Literal ;
         sh:datatype rdf:langString ;
-        sh:languageIn ( "de" "fr" "it" ) ;
+        sh:languageIn ( "de" "fr" "it" "en" ) ;
         sh:uniqueLang true ;
     ],
     [
@@ -349,8 +349,7 @@ cultivationtype:509 a owl:Class ;
         "Riso"@it ;
     schema:description "Der Anbau von Reis auf offener Fläche."@de ;
     rdfs:subClassOf cultivationtype:1033 ;
-    :botanicalPlant taxon:ORYSA ;
-    :cultivationMethod :11 .
+    :botanicalPlant taxon:ORYSA .
 
 cultivationtype:510 a owl:Class ;
     schema:name "Hartweizen"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -37,10 +37,11 @@ cultivationtype:shape a sh:NodeShape ;
     sh:property
     [
         sh:path schema:name ;
-        sh:minCount 3 ;
+        sh:minCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:datatype rdf:langString ;
         sh:languageIn ( "de" "fr" "it" ) ;
+        sh:uniqueLang true ;
     ],
     [
         sh:path schema:alternateName ;
@@ -53,6 +54,7 @@ cultivationtype:shape a sh:NodeShape ;
         sh:nodeKind sh:Literal ;
         sh:datatype rdf:langString ;
         sh:languageIn ( "de" "fr" "it" ) ;
+        sh:uniqueLang true ;
     ],
     [
         sh:path rdfs:subClassOf ;


### PR DESCRIPTION
- Set up SHACL validation for all (relevant) RDF files.
- Relax SHACL constraints for cultivation types (no translations required for now)
- Closes blw-ofag-ufag/eCH-0265#352 