### PR TITLE
115 srppp is missing parts of the crop taxonomy

### DIFF
--- a/.github/workflows/graph-pipeline.yml
+++ b/.github/workflows/graph-pipeline.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         test-file: 
           - tests/test_turtle_syntax.py
+          - tests/test_psm_polyhierarchy_consistency.py
     
     steps:
       - name: Checkout Repository

--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -470,6 +470,8 @@ psm:1 a cube:Observation ;
 
 psm:10 a cube:Observation ;
     schema:identifier "9C6CEE37-8105-4E48-9CA4-11BA3AB556FB"^^xsd:ID ;
+    schema:isPartOf psm:145,
+        psm:310 ;
     schema:name "Gerbera"@de,
         "Gerbera"@en,
         "gerbera"@fr,
@@ -479,7 +481,8 @@ psm:10 a cube:Observation ;
 
 psm:100 a cube:Observation ;
     schema:identifier "99379C08-8682-4628-BD67-6E566F5130FA"^^xsd:ID ;
-    schema:isPartOf psm:27, psm:316 ;
+    schema:isPartOf psm:27,
+        psm:316 ;
     schema:name "Trockenreis"@de,
         "Riz semis sur terrain sec"@fr,
         "Riso seminato su terreno asciutto"@it ;
@@ -488,6 +491,8 @@ psm:100 a cube:Observation ;
 
 psm:101 a cube:Observation ;
     schema:identifier "9A9A2586-34FF-4256-8FA4-BA9F2FA38CAE"^^xsd:ID ;
+    schema:isPartOf psm:108,
+        psm:145 ;
     schema:name "Cyclame"@de,
         "cyclamen"@fr,
         "Ciclamino"@it ;
@@ -692,6 +697,8 @@ psm:121 a cube:Observation ;
 
 psm:122 a cube:Observation ;
     schema:identifier "ED17FD35-4C96-4D28-902B-ACEA3F4950D6"^^xsd:ID ;
+    schema:isPartOf psm:118,
+        psm:72 ;
     schema:name "Zypressengewächse"@de,
         "Cupressaceae"@en,
         "cupressacées"@fr,
@@ -737,6 +744,8 @@ psm:126 a cube:Observation ;
 
 psm:127 a cube:Observation ;
     schema:identifier "F730D531-B0C8-4A20-AC4B-4F86445E2491"^^xsd:ID ;
+    schema:isPartOf psm:210,
+        psm:239 ;
     schema:name "Emmer"@de,
         "Amidonnier"@fr,
         "Farro"@it ;
@@ -941,6 +950,8 @@ psm:147 a cube:Observation ;
 
 psm:148 a cube:Observation ;
     schema:identifier "7D65DFD2-C26E-4CAB-9E2C-66A6C7CBA641"^^xsd:ID ;
+    schema:isPartOf psm:197,
+        psm:210 ;
     schema:name "Wintergerste"@de,
         "Orge d'automne"@fr,
         "Orzo autunnale"@it ;
@@ -994,7 +1005,8 @@ psm:152 a cube:Observation ;
 
 psm:153 a cube:Observation ;
     schema:identifier "79C28385-E183-4661-AAC0-80E82C67089C"^^xsd:ID ;
-    schema:isPartOf psm:118 ;
+    schema:isPartOf psm:118,
+        psm:72 ;
     schema:name "Weihnachtsbäume"@de,
         "arbres de Noël"@fr,
         "Alberi di Natale"@it ;
@@ -1012,6 +1024,8 @@ psm:154 a cube:Observation ;
 
 psm:155 a cube:Observation ;
     schema:identifier "B75AC4CC-6BB7-4A99-808A-9F7BDFCF8E6A"^^xsd:ID ;
+    schema:isPartOf psm:108,
+        psm:145 ;
     schema:name "Pelargonien"@de,
         "géranium"@fr,
         "Geranio"@it ;
@@ -1082,6 +1096,8 @@ psm:161 a cube:Observation ;
 
 psm:162 a cube:Observation ;
     schema:identifier "43FC7C18-BDA5-4364-B4CA-74EA37B7B8DC"^^xsd:ID ;
+    schema:isPartOf psm:296,
+        psm:333 ;
     schema:name "Forstliche Pflanzgärten"@de,
         "pépinières forestières"@fr,
         "Vivai forestali"@it ;
@@ -1124,6 +1140,8 @@ psm:166 a cube:Observation ;
 
 psm:167 a cube:Observation ;
     schema:identifier "5B651459-FC70-4D22-9469-4991F847EA89"^^xsd:ID ;
+    schema:isPartOf psm:118,
+        psm:72 ;
     schema:name "Blautanne"@de,
         "sapin bleu"@fr,
         "Abete del Colorado"@it ;
@@ -1381,6 +1399,8 @@ psm:192 a cube:Observation ;
 
 psm:193 a cube:Observation ;
     schema:identifier "7AB6690B-B2B9-4F12-AFAE-A9B0222C2637"^^xsd:ID ;
+    schema:isPartOf psm:210,
+        psm:71 ;
     schema:name "Winterweizen"@de,
         "Blé d'automne"@fr,
         "Frumento autunnale"@it ;
@@ -1397,7 +1417,8 @@ psm:194 a cube:Observation ;
 
 psm:195 a cube:Observation ;
     schema:identifier "61D9C648-0736-43D4-BF04-B8643B1D74E0"^^xsd:ID ;
-    schema:isPartOf psm:4 ;
+    schema:isPartOf psm:145,
+        psm:4 ;
     schema:name "Hyazinthe"@de,
         "jacinthe"@fr,
         "Giacinto"@it ;
@@ -1659,6 +1680,8 @@ psm:22 a cube:Observation ;
 
 psm:220 a cube:Observation ;
     schema:identifier "F9426E5C-7D4D-45E5-80DA-64BB12336CA4"^^xsd:ID ;
+    schema:isPartOf psm:27,
+        psm:316 ;
     schema:name "Mais"@de,
         "Maïs"@fr,
         "Mais"@it ;
@@ -1712,7 +1735,8 @@ psm:225 a cube:Observation ;
 
 psm:226 a cube:Observation ;
     schema:identifier "B74E61A6-30BD-4A63-8A24-94FC0A54D489"^^xsd:ID ;
-    schema:isPartOf psm:149 ;
+    schema:isPartOf psm:149,
+        psm:210 ;
     schema:name "Winterroggen"@de,
         "Seigle d'automne"@fr,
         "Segale autunnale"@it ;
@@ -1747,6 +1771,8 @@ psm:229 a cube:Observation ;
 
 psm:23 a cube:Observation ;
     schema:identifier "3A53A166-7559-4E75-BDED-F65CA6FDFDE1"^^xsd:ID ;
+    schema:isPartOf psm:16,
+        psm:72 ;
     schema:name "Rhododendron"@de,
         "rhododendron"@fr,
         "Rododendro"@it ;
@@ -1827,6 +1853,8 @@ psm:237 a cube:Observation ;
 
 psm:238 a cube:Observation ;
     schema:identifier "83A9CEC5-FC31-421C-A3B8-CA219AF649CF"^^xsd:ID ;
+    schema:isPartOf psm:145,
+        psm:310 ;
     schema:name "Nelken"@de,
         "oeillet"@fr,
         "Garofani"@it ;
@@ -2356,7 +2384,8 @@ psm:290 a cube:Observation ;
 
 psm:291 a cube:Observation ;
     schema:identifier "B6669854-1833-4BBC-A931-E67505848EA7"^^xsd:ID ;
-    schema:isPartOf psm:163 ;
+    schema:isPartOf psm:163,
+        psm:71 ;
     schema:name "Sommerweizen"@de,
         "Blé de printemps"@fr,
         "Frumento primaverile"@it ;
@@ -2443,6 +2472,8 @@ psm:3 a cube:Observation ;
 
 psm:30 a cube:Observation ;
     schema:identifier "2F7BD13A-BAA5-4708-83C6-17D44E57EA4D"^^xsd:ID ;
+    schema:isPartOf psm:16,
+        psm:72 ;
     schema:name "Rosskastanie"@de,
         "marronnier d'Inde"@fr,
         "Ippocastano"@it ;
@@ -2595,6 +2626,8 @@ psm:314 a cube:Observation ;
 
 psm:315 a cube:Observation ;
     schema:identifier "34753E17-C34D-4D0B-88A0-91143DADABB2"^^xsd:ID ;
+    schema:isPartOf psm:145,
+        psm:310 ;
     schema:name "Chrysantheme"@de,
         "chrysanthème"@fr,
         "Crisantemo"@it ;
@@ -2805,7 +2838,8 @@ psm:336 a cube:Observation ;
 
 psm:34 a cube:Observation ;
     schema:identifier "2E38C972-4160-4D2B-8ED2-3B48FC781EF0"^^xsd:ID ;
-    schema:isPartOf psm:145 ;
+    schema:isPartOf psm:108,
+        psm:145 ;
     schema:name "Begonia"@de,
         "bégonia"@fr,
         "Begonia"@it ;
@@ -2895,6 +2929,8 @@ psm:42 a cube:Observation ;
 
 psm:43 a cube:Observation ;
     schema:identifier "FFDDDA7D-B340-473C-94F4-841272B602FA"^^xsd:ID ;
+    schema:isPartOf psm:131,
+        psm:266 ;
     schema:name "Jostabeere"@de,
         "josta"@fr,
         "Josta"@it ;
@@ -2919,6 +2955,8 @@ psm:45 a cube:Observation ;
 
 psm:46 a cube:Observation ;
     schema:identifier "DAF00AE7-5272-4E07-9A66-E9F9BD8FEE43"^^xsd:ID ;
+    schema:isPartOf psm:145,
+        psm:310 ;
     schema:name "Blaudistel"@de,
         "chardon bleu"@fr,
         "Cardo azzurro"@it ;
@@ -2980,7 +3018,8 @@ psm:51 a cube:Observation ;
 
 psm:52 a cube:Observation ;
     schema:identifier "CEC488FC-D9AD-4515-A28E-DEEC6C807926"^^xsd:ID ;
-    schema:isPartOf psm:303 ;
+    schema:isPartOf psm:210,
+        psm:303 ;
     schema:name "Wintertriticale"@de,
         "Triticale d'automne"@fr,
         "Triticale autunnale"@it ;
@@ -3043,6 +3082,8 @@ psm:58 a cube:Observation ;
 
 psm:59 a cube:Observation ;
     schema:identifier "C026CB2D-39B4-4FDF-AD04-FBA22AD2B4F1"^^xsd:ID ;
+    schema:isPartOf psm:163,
+        psm:197 ;
     schema:name "Sommergerste"@de,
         "orge de printemps"@fr,
         "Orzo primaverile"@it ;
@@ -3051,6 +3092,8 @@ psm:59 a cube:Observation ;
 
 psm:6 a cube:Observation ;
     schema:identifier "A21391C3-A1A3-4472-8AA1-56449FB56B36"^^xsd:ID ;
+    schema:isPartOf psm:16,
+        psm:72 ;
     schema:name "Kirschlorbeer"@de,
         "laurier-cerise"@fr,
         "Lauro ceraso"@it ;
@@ -3082,7 +3125,8 @@ psm:62 a cube:Observation ;
 
 psm:63 a cube:Observation ;
     schema:identifier "DF455946-B2AB-45D2-9780-4A45A98D72D6"^^xsd:ID ;
-    schema:isPartOf psm:16 ;
+    schema:isPartOf psm:16,
+        psm:72 ;
     schema:name "Buchsbäume (Buxus)"@de,
         "buis (Buxus)"@fr,
         "Bosso (Buxus)"@it ;
@@ -3100,6 +3144,8 @@ psm:64 a cube:Observation ;
 
 psm:65 a cube:Observation ;
     schema:identifier "E8B23A5E-B65E-4DC8-977D-BD84F143A442"^^xsd:ID ;
+    schema:isPartOf psm:108,
+        psm:145 ;
     schema:name "Primeln"@de,
         "primevères"@fr,
         "Primule"@it ;
@@ -3152,6 +3198,8 @@ psm:7 a cube:Observation ;
 
 psm:70 a cube:Observation ;
     schema:identifier "D3D49C53-8EBC-4DAC-9C4C-B988AA162F7D"^^xsd:ID ;
+    schema:isPartOf psm:210,
+        psm:239 ;
     schema:name "Korn (Dinkel)"@de,
         "Épeautre"@fr,
         "Spelta"@it ;
@@ -3178,6 +3226,8 @@ psm:72 a cube:Observation ;
 
 psm:73 a cube:Observation ;
     schema:identifier "8B5A3E2B-2534-4FC0-84C5-685915165A77"^^xsd:ID ;
+    schema:isPartOf psm:27,
+        psm:316 ;
     schema:name "Getreide"@de,
         "Céréales"@fr,
         "Cereali"@it ;
@@ -3222,6 +3272,8 @@ psm:77 a cube:Observation ;
 
 psm:78 a cube:Observation ;
     schema:identifier "C9DB1105-33C7-44E8-92BA-9BBE5BA2BB3F"^^xsd:ID ;
+    schema:isPartOf psm:128,
+        psm:163 ;
     schema:name "Sommerhafer"@de,
         "Avoine de printemps"@fr,
         "Avena primaverile"@it ;
@@ -3398,7 +3450,8 @@ psm:95 a cube:Observation ;
 
 psm:96 a cube:Observation ;
     schema:identifier "B4D50F5E-6028-493D-9B95-85CAE5DADF06"^^xsd:ID ;
-    schema:isPartOf psm:316 ;
+    schema:isPartOf psm:27,
+        psm:316 ;
     schema:name "Kartoffeln"@de,
         "pommes de terre"@fr,
         "Patate"@it ;
@@ -3416,6 +3469,8 @@ psm:97 a cube:Observation ;
 
 psm:98 a cube:Observation ;
     schema:identifier "E2A335E5-D797-46E7-9CE4-9CB3F301AAA2"^^xsd:ID ;
+    schema:isPartOf psm:145,
+        psm:310 ;
     schema:name "Gladiole"@de,
         "glaïeul"@fr,
         "Gladiolo"@it ;

--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -479,6 +479,7 @@ psm:10 a cube:Observation ;
 
 psm:100 a cube:Observation ;
     schema:identifier "99379C08-8682-4628-BD67-6E566F5130FA"^^xsd:ID ;
+    schema:isPartOf psm:27 ;
     schema:name "Trockenreis"@de,
         "Riz semis sur terrain sec"@fr,
         "Riso seminato su terreno asciutto"@it ;
@@ -993,6 +994,7 @@ psm:152 a cube:Observation ;
 
 psm:153 a cube:Observation ;
     schema:identifier "79C28385-E183-4661-AAC0-80E82C67089C"^^xsd:ID ;
+    schema:isPartOf psm:118 ;
     schema:name "Weihnachtsbäume"@de,
         "arbres de Noël"@fr,
         "Alberi di Natale"@it ;
@@ -1709,6 +1711,7 @@ psm:225 a cube:Observation ;
 
 psm:226 a cube:Observation ;
     schema:identifier "B74E61A6-30BD-4A63-8A24-94FC0A54D489"^^xsd:ID ;
+    schema:isPartOf psm:149 ;
     schema:name "Winterroggen"@de,
         "Seigle d'automne"@fr,
         "Segale autunnale"@it ;
@@ -2352,6 +2355,7 @@ psm:290 a cube:Observation ;
 
 psm:291 a cube:Observation ;
     schema:identifier "B6669854-1833-4BBC-A931-E67505848EA7"^^xsd:ID ;
+    schema:isPartOf psm:163 ;
     schema:name "Sommerweizen"@de,
         "Blé de printemps"@fr,
         "Frumento primaverile"@it ;
@@ -2800,6 +2804,7 @@ psm:336 a cube:Observation ;
 
 psm:34 a cube:Observation ;
     schema:identifier "2E38C972-4160-4D2B-8ED2-3B48FC781EF0"^^xsd:ID ;
+    schema:isPartOf psm:145 ;
     schema:name "Begonia"@de,
         "bégonia"@fr,
         "Begonia"@it ;
@@ -2974,6 +2979,7 @@ psm:51 a cube:Observation ;
 
 psm:52 a cube:Observation ;
     schema:identifier "CEC488FC-D9AD-4515-A28E-DEEC6C807926"^^xsd:ID ;
+    schema:isPartOf psm:303 ;
     schema:name "Wintertriticale"@de,
         "Triticale d'automne"@fr,
         "Triticale autunnale"@it ;
@@ -3075,6 +3081,7 @@ psm:62 a cube:Observation ;
 
 psm:63 a cube:Observation ;
     schema:identifier "DF455946-B2AB-45D2-9780-4A45A98D72D6"^^xsd:ID ;
+    schema:isPartOf psm:16 ;
     schema:name "Buchsbäume (Buxus)"@de,
         "buis (Buxus)"@fr,
         "Bosso (Buxus)"@it ;
@@ -3390,6 +3397,7 @@ psm:95 a cube:Observation ;
 
 psm:96 a cube:Observation ;
     schema:identifier "B4D50F5E-6028-493D-9B95-85CAE5DADF06"^^xsd:ID ;
+    schema:isPartOf psm:316 ;
     schema:name "Kartoffeln"@de,
         "pommes de terre"@fr,
         "Patate"@it ;

--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -479,7 +479,7 @@ psm:10 a cube:Observation ;
 
 psm:100 a cube:Observation ;
     schema:identifier "99379C08-8682-4628-BD67-6E566F5130FA"^^xsd:ID ;
-    schema:isPartOf psm:27 ;
+    schema:isPartOf psm:27, psm:316 ;
     schema:name "Trockenreis"@de,
         "Riz semis sur terrain sec"@fr,
         "Riso seminato su terreno asciutto"@it ;
@@ -1397,6 +1397,7 @@ psm:194 a cube:Observation ;
 
 psm:195 a cube:Observation ;
     schema:identifier "61D9C648-0736-43D4-BF04-B8643B1D74E0"^^xsd:ID ;
+    schema:isPartOf psm:4 ;
     schema:name "Hyazinthe"@de,
         "jacinthe"@fr,
         "Giacinto"@it ;

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -17,7 +17,7 @@ pyproj==3.7.2
 pytest==9.0.3
 python-dateutil==2.9.0.post0
 pytz==2026.1.post1
-rdflib==7.2.1
+rdflib==7.6.0
 requests==2.32.3
 shapely==2.1.2
 six==1.17.0

--- a/tests/test_psm_polyhierarchy_consistency.py
+++ b/tests/test_psm_polyhierarchy_consistency.py
@@ -72,25 +72,36 @@ def test_culture_hierarchy_exists_in_rdf():
     # ==========================================
     # 3. Validation and Error Reporting
     # ==========================================
-    missing_pairs = []
     
-    for csv_id, csv_parent_id in csv_pairs:
-        if (csv_id, csv_parent_id) not in rdf_pairs:
-            missing_pairs.append((csv_id, csv_parent_id))
-            
-    # If the missing_pairs list isn't empty, fail the test with a detailed message
-    if missing_pairs:
-        error_msg = (
-            f"Found {len(missing_pairs)} 'Culture' combinations in the CSV "
-            f"that are MISSING from the RDF graph ({RDF_FILE_PATH}).\n\n"
-            "Sample of missing (ID, PARENT_ID) combinations:\n"
-        )
+    # Calculate bidirectional differences
+    missing_in_rdf = csv_pairs - rdf_pairs
+    extra_in_rdf = rdf_pairs - csv_pairs
+    
+    # If either set is not empty, we have a mismatch
+    if missing_in_rdf or extra_in_rdf:
+        error_msg = "Exact match validation failed between CSV hierarchy and RDF graph.\n\n"
         
-        # Limit to first 20 to avoid flooding the console output on massive failures
-        for m_id, m_parent in missing_pairs[:20]:
-            error_msg += f"  → ID: {m_id} | PARENT_ID: {m_parent}\n"
-            
-        if len(missing_pairs) > 20:
-            error_msg += f"  ... and {len(missing_pairs) - 20} more."
-            
-        pytest.fail(error_msg)
+        # 3a. Report what is in CSV but missing from RDF
+        if missing_in_rdf:
+            error_msg += (
+                f"[{len(missing_in_rdf)} MISSING IN RDF] Found in CSV, but not in RDF:\n"
+            )
+            for m_id, m_parent in list(missing_in_rdf)[:20]:
+                error_msg += f"  → ID: {m_id} | PARENT_ID: {m_parent}\n"
+                
+            if len(missing_in_rdf) > 20:
+                error_msg += f"  ... and {len(missing_in_rdf) - 20} more.\n"
+            error_msg += "\n"
+
+        # 3b. Report what is in RDF but missing from CSV
+        if extra_in_rdf:
+            error_msg += (
+                f"[{len(extra_in_rdf)} EXTRA IN RDF] Found in RDF, but not in CSV (TEXT_KEY == 'Culture'):\n"
+            )
+            for e_id, e_parent in list(extra_in_rdf)[:20]:
+                error_msg += f"  → ID: {e_id} | PARENT_ID: {e_parent}\n"
+                
+            if len(extra_in_rdf) > 20:
+                error_msg += f"  ... and {len(extra_in_rdf) - 20} more.\n"
+
+        pytest.fail(error_msg.strip())

--- a/tests/test_psm_polyhierarchy_consistency.py
+++ b/tests/test_psm_polyhierarchy_consistency.py
@@ -1,0 +1,96 @@
+import pytest
+import requests
+import csv
+import io
+from rdflib import Graph
+
+# Configuration
+RDF_FILE_PATH = "./rdf/data/srppp.ttl"
+CSV_URL = "https://raw.githubusercontent.com/BLV-OSAV-USAV/PSMV-RDF/refs/heads/main/data/raw/Code.csv"
+
+def test_culture_hierarchy_exists_in_rdf():
+    """
+    Tests that every (ID, PARENT_ID) combination for TEXT_KEY == 'Culture' 
+    in the remote CSV exists in the local RDF graph.
+    """
+    
+    # ==========================================
+    # 1. Fetch and process the remote CSV data
+    # ==========================================
+    try:
+        response = requests.get(CSV_URL, timeout=10)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        pytest.fail(f"Failed to download CSV from {CSV_URL}\nError: {e}")
+
+    # Parse the CSV and mirror the R `subset` logic
+    csv_pairs = set()
+    reader = csv.DictReader(io.StringIO(response.text))
+    
+    for row in reader:
+        if row.get("TEXT_KEY") == "Culture":
+            # Extract and clean the strings to avoid whitespace mismatch issues
+            c_id = str(row.get("ID", "")).strip()
+            c_parent_id = str(row.get("PARENT_ID", "")).strip()
+            
+            # Only add if both fields are populated
+            if c_id and c_parent_id:
+                csv_pairs.add((c_id, c_parent_id))
+                
+    if not csv_pairs:
+        pytest.fail("The CSV filter returned 0 results. Check if the CSV structure or TEXT_KEY changed.")
+
+    # ==========================================
+    # 2. Parse the RDF file and run SPARQL
+    # ==========================================
+    g = Graph()
+    try:
+        g.parse(RDF_FILE_PATH, format="turtle")
+    except Exception as e:
+        pytest.fail(f"Failed to parse the local RDF file at {RDF_FILE_PATH}\nError: {e}")
+
+    sparql_query = """
+    PREFIX cube: <https://cube.link/>
+    PREFIX schema: <http://schema.org/>
+    SELECT ?id ?parent_id
+    WHERE {
+      [
+        a cube:Observation ;
+        schema:identifier ?id ;
+        schema:isPartOf / schema:identifier ?parent_id ;
+      ]
+    }
+    """
+    
+    rdf_pairs = set()
+    for row in g.query(sparql_query):
+        # Convert rdflib Literal/URIRef objects to standard Python strings for direct comparison
+        r_id = str(row.id).strip()
+        r_parent_id = str(row.parent_id).strip()
+        rdf_pairs.add((r_id, r_parent_id))
+
+    # ==========================================
+    # 3. Validation and Error Reporting
+    # ==========================================
+    missing_pairs = []
+    
+    for csv_id, csv_parent_id in csv_pairs:
+        if (csv_id, csv_parent_id) not in rdf_pairs:
+            missing_pairs.append((csv_id, csv_parent_id))
+            
+    # If the missing_pairs list isn't empty, fail the test with a detailed message
+    if missing_pairs:
+        error_msg = (
+            f"Found {len(missing_pairs)} 'Culture' combinations in the CSV "
+            f"that are MISSING from the RDF graph ({RDF_FILE_PATH}).\n\n"
+            "Sample of missing (ID, PARENT_ID) combinations:\n"
+        )
+        
+        # Limit to first 20 to avoid flooding the console output on massive failures
+        for m_id, m_parent in missing_pairs[:20]:
+            error_msg += f"  → ID: {m_id} | PARENT_ID: {m_parent}\n"
+            
+        if len(missing_pairs) > 20:
+            error_msg += f"  ... and {len(missing_pairs) - 20} more."
+            
+        pytest.fail(error_msg)

--- a/tests/test_psm_polyhierarchy_consistency.py
+++ b/tests/test_psm_polyhierarchy_consistency.py
@@ -8,10 +8,10 @@ from rdflib import Graph
 RDF_FILE_PATH = "./rdf/data/srppp.ttl"
 CSV_URL = "https://raw.githubusercontent.com/BLV-OSAV-USAV/PSMV-RDF/refs/heads/main/data/raw/Code.csv"
 
-def test_culture_hierarchy_exists_in_rdf():
+def test_culture_consistency_in_rdf():
     """
-    Tests that every (ID, PARENT_ID) combination for TEXT_KEY == 'Culture' 
-    in the remote CSV exists in the local RDF graph.
+    Tests that the hierarchy (ID, PARENT_ID) AND the localized names (ID, LANGUAGE, VALUE)
+    in the remote CSV (for TEXT_KEY == 'Culture') EXACTLY MATCH the local RDF graph.
     """
     
     # ==========================================
@@ -23,25 +23,31 @@ def test_culture_hierarchy_exists_in_rdf():
     except requests.exceptions.RequestException as e:
         pytest.fail(f"Failed to download CSV from {CSV_URL}\nError: {e}")
 
-    # Parse the CSV and mirror the R `subset` logic
-    csv_pairs = set()
+    csv_hierarchy = set()
+    csv_names = set()
+    
     reader = csv.DictReader(io.StringIO(response.text))
     
     for row in reader:
         if row.get("TEXT_KEY") == "Culture":
-            # Extract and clean the strings to avoid whitespace mismatch issues
             c_id = str(row.get("ID", "")).strip()
             c_parent_id = str(row.get("PARENT_ID", "")).strip()
+            c_lang = str(row.get("LANGUAGE", "")).strip().lower()
+            c_val = str(row.get("VALUE", "")).strip()
             
-            # Only add if both fields are populated
+            # Populate Hierarchy Set
             if c_id and c_parent_id:
-                csv_pairs.add((c_id, c_parent_id))
+                csv_hierarchy.add((c_id, c_parent_id))
+            
+            # Populate Names Set
+            if c_id and c_lang and c_val:
+                csv_names.add((c_id, c_lang, c_val))
                 
-    if not csv_pairs:
-        pytest.fail("The CSV filter returned 0 results. Check if the CSV structure or TEXT_KEY changed.")
+    if not csv_hierarchy and not csv_names:
+        pytest.fail("The CSV filter returned 0 results. Check if the CSV structure changed.")
 
     # ==========================================
-    # 2. Parse the RDF file and run SPARQL
+    # 2. Parse the RDF file
     # ==========================================
     g = Graph()
     try:
@@ -49,7 +55,14 @@ def test_culture_hierarchy_exists_in_rdf():
     except Exception as e:
         pytest.fail(f"Failed to parse the local RDF file at {RDF_FILE_PATH}\nError: {e}")
 
-    sparql_query = """
+    # ==========================================
+    # 3. Extract RDF Hierarchy and Names
+    # ==========================================
+    rdf_hierarchy = set()
+    rdf_names = set()
+
+    # Query 1: Hierarchy
+    sparql_hierarchy = """
     PREFIX cube: <https://cube.link/>
     PREFIX schema: <http://schema.org/>
     SELECT ?id ?parent_id
@@ -61,47 +74,73 @@ def test_culture_hierarchy_exists_in_rdf():
       ]
     }
     """
-    
-    rdf_pairs = set()
-    for row in g.query(sparql_query):
-        # Convert rdflib Literal/URIRef objects to standard Python strings for direct comparison
+    for row in g.query(sparql_hierarchy):
+        rdf_hierarchy.add((str(row.id).strip(), str(row.parent_id).strip()))
+
+    # Query 2: Localized Names
+    sparql_names = """
+    PREFIX cube: <https://cube.link/>
+    PREFIX schema: <http://schema.org/>
+    SELECT ?id ?name
+    WHERE {
+      ?obs a cube:Observation ;
+           schema:identifier ?id ;
+           schema:name ?name .
+    }
+    """
+    for row in g.query(sparql_names):
         r_id = str(row.id).strip()
-        r_parent_id = str(row.parent_id).strip()
-        rdf_pairs.add((r_id, r_parent_id))
+        r_val = str(row.name).strip()
+        # Extract the language tag (e.g., 'de' from "Gladiole"@de)
+        r_lang = str(row.name.language).lower() if row.name.language else ""
+        rdf_names.add((r_id, r_lang, r_val))
 
     # ==========================================
-    # 3. Validation and Error Reporting
+    # 4. Validation and Error Reporting
     # ==========================================
     
-    # Calculate bidirectional differences
-    missing_in_rdf = csv_pairs - rdf_pairs
-    extra_in_rdf = rdf_pairs - csv_pairs
+    # Calculate bidirectional differences for both datasets
+    missing_hierarchy_in_rdf = csv_hierarchy - rdf_hierarchy
+    extra_hierarchy_in_rdf = rdf_hierarchy - csv_hierarchy
     
-    # If either set is not empty, we have a mismatch
-    if missing_in_rdf or extra_in_rdf:
-        error_msg = "Exact match validation failed between CSV hierarchy and RDF graph.\n\n"
+    missing_names_in_rdf = csv_names - rdf_names
+    extra_names_in_rdf = rdf_names - csv_names
+    
+    # If any set is not empty, we compile a master error message
+    if any([missing_hierarchy_in_rdf, extra_hierarchy_in_rdf, missing_names_in_rdf, extra_names_in_rdf]):
+        error_msg = "Exact match validation failed between CSV and RDF graph.\n\n"
         
-        # 3a. Report what is in CSV but missing from RDF
-        if missing_in_rdf:
-            error_msg += (
-                f"[{len(missing_in_rdf)} MISSING IN RDF] Found in CSV, but not in RDF:\n"
-            )
-            for m_id, m_parent in list(missing_in_rdf)[:20]:
+        # --- HIERARCHY ERRORS ---
+        if missing_hierarchy_in_rdf:
+            error_msg += f"[{len(missing_hierarchy_in_rdf)} MISSING HIERARCHY IN RDF] Found in CSV, but not in RDF:\n"
+            for m_id, m_parent in list(missing_hierarchy_in_rdf)[:10]:
                 error_msg += f"  → ID: {m_id} | PARENT_ID: {m_parent}\n"
-                
-            if len(missing_in_rdf) > 20:
-                error_msg += f"  ... and {len(missing_in_rdf) - 20} more.\n"
+            if len(missing_hierarchy_in_rdf) > 10:
+                error_msg += f"  ... and {len(missing_hierarchy_in_rdf) - 10} more.\n"
             error_msg += "\n"
 
-        # 3b. Report what is in RDF but missing from CSV
-        if extra_in_rdf:
-            error_msg += (
-                f"[{len(extra_in_rdf)} EXTRA IN RDF] Found in RDF, but not in CSV (TEXT_KEY == 'Culture'):\n"
-            )
-            for e_id, e_parent in list(extra_in_rdf)[:20]:
+        if extra_hierarchy_in_rdf:
+            error_msg += f"[{len(extra_hierarchy_in_rdf)} EXTRA HIERARCHY IN RDF] Found in RDF, but not in CSV:\n"
+            for e_id, e_parent in list(extra_hierarchy_in_rdf)[:10]:
                 error_msg += f"  → ID: {e_id} | PARENT_ID: {e_parent}\n"
-                
-            if len(extra_in_rdf) > 20:
-                error_msg += f"  ... and {len(extra_in_rdf) - 20} more.\n"
+            if len(extra_hierarchy_in_rdf) > 10:
+                error_msg += f"  ... and {len(extra_hierarchy_in_rdf) - 10} more.\n"
+            error_msg += "\n"
+
+        # --- NAME ERRORS ---
+        if missing_names_in_rdf:
+            error_msg += f"[{len(missing_names_in_rdf)} MISSING NAMES IN RDF] Found in CSV, but not in RDF:\n"
+            for m_id, m_lang, m_val in list(missing_names_in_rdf)[:10]:
+                error_msg += f"  → ID: {m_id} | LANG: '{m_lang}' | VALUE: '{m_val}'\n"
+            if len(missing_names_in_rdf) > 10:
+                error_msg += f"  ... and {len(missing_names_in_rdf) - 10} more.\n"
+            error_msg += "\n"
+
+        if extra_names_in_rdf:
+            error_msg += f"[{len(extra_names_in_rdf)} EXTRA NAMES IN RDF] Found in RDF, but not in CSV:\n"
+            for e_id, e_lang, e_val in list(extra_names_in_rdf)[:10]:
+                error_msg += f"  → ID: {e_id} | LANG: '{e_lang}' | VALUE: '{e_val}'\n"
+            if len(extra_names_in_rdf) > 10:
+                error_msg += f"  ... and {len(extra_names_in_rdf) - 10} more.\n"
 
         pytest.fail(error_msg.strip())


### PR DESCRIPTION
## Description

This PR resolves the missing parts of the crop taxonomy outlined in #115 and introduces strict, automated validation to ensure our RDF graph remains perfectly synchronized with the source CSV data moving forward.

Closes #115

## Technical changes

- Introduced a new pytest suite (`tests/test_psm_polyhierarchy_consistency.py`) that fetches the remote infofito export (`Code.csv`) from <https://github.com/BLV-OSAV-USAV/PSMV-RDF> and performs a strict validation against our local `srppp.ttl` graph.
- The test ensures that the `(ID, PARENT_ID)` combinations in the CSV perfectly match the `schema:isPartOf` triples in the RDF graph. It will fail if any relations are missing *or* if there are unexpected extra relations in the RDF.
- Extended the test to validate that all `schema:name` literals are correctly applied with their exact language tags (`@de`, `@fr`, `@it`). 
- Added the new test to the GitHub Actions pipeline so any future PRs that break the taxonomy sync will fail automatically.

## Fixes

- Added missing `schema:isPartOf` triples into the taxonomy to satisfy the new constraints.
- Addressed and resolved the `DeprecationWarning` spam originating from the `rdflib`/`pyparsing` interaction during SPARQL parsing.

## Running the test

You can run the full suite or isolate the new polyhierarchy test to verify the consistency:

``` bash
# Run all tests
pytest

# Run only the new consistency test
pytest tests/test_psm_polyhierarchy_consistency.py
```

## Checklist

- [x] All missing `schema:isPartOf` relations have been added.
- [x] Pytest script is fully functional and performs bidirectional checks.
- [x] GitHub Actions workflows updated.
- [x] All tests currently pass locally and in CI.