### PR TITLE
Map and integrate PSM-vines

### DIFF
--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -1023,7 +1023,7 @@ psm:156 a cube:Observation ;
         "jeune vigne"@fr,
         "Ceppi giovani"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:156 .
 
 psm:157 a cube:Observation ;
     schema:identifier "4D799EC6-1483-4D65-90EA-8DDB6A4166CA"^^xsd:ID ;
@@ -1225,7 +1225,7 @@ psm:177 a cube:Observation ;
         "vigne"@fr,
         "Vite"@it ;
     schema:version 0 ;
-    :cultivationType cultivationtype:177 .
+    :cultivationType cultivationtype:4 .
 
 psm:178 a cube:Observation ;
     schema:identifier "6569FC94-60C5-4608-8926-D76D2009B284"^^xsd:ID ;
@@ -1589,7 +1589,7 @@ psm:213 a cube:Observation ;
         "vigne en production"@fr,
         "Vite in produzione"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:213 .
 
 psm:214 a cube:Observation ;
     schema:identifier "FF0DF95C-A3A9-47EE-95FA-00FCB428A4ED"^^xsd:ID ;

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -142,7 +142,8 @@ cultivationtype:4 a owl:Class ;
     schema:name "Reben"@de,
         "Vignobles"@fr,
         "Vigna"@it ;
-    rdfs:subClassOf :Cultivation .
+    rdfs:subClassOf :Cultivation ;
+    owl:unionOf ( cultivationtype:701 cultivationtype:735 ) .
 
 cultivationtype:5 a owl:Class ;
     schema:name "Obstanlagen"@de,
@@ -2090,10 +2091,8 @@ cultivationtype:698 a owl:Class ;
     rdfs:subClassOf cultivationtype:2 .
 
 cultivationtype:701 a owl:Class ;
-    schema:name "Reben"@de,
-        "Vignes"@fr,
-        "Vigna"@it ;
-    rdfs:subClassOf cultivationtype:4 .
+    schema:name "Reben (ohne regionsspezifische Biodiversitätsförderflächen)"@de ;
+    owl:disjointWith cultivationtype:735 .
 
 cultivationtype:702 a owl:Class ;
     schema:name "Obstanlagen (Äpfel)"@de,
@@ -2249,8 +2248,7 @@ cultivationtype:731 a owl:Class ;
 cultivationtype:735 a owl:Class ;
     schema:name "Reben (regionsspezifische Biodiversitätsförderflächen)"@de,
         "Vignes (surfaces de promotion de la biodiversité spécifiques à la ré-gion)"@fr,
-        "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:4 .
+        "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it .
 
 cultivationtype:750 a owl:Class ;
     schema:name "Übrige Dauerkulturen, beitragsberechtigt, aggregiert"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -141,7 +141,8 @@ cultivationtype:3 a owl:Class ;
 cultivationtype:4 a owl:Class ;
     schema:name "Reben"@de,
         "Vignobles"@fr,
-        "Vigna"@it ;
+        "Vigna"@it,
+        "Vines"@en ;
     rdfs:subClassOf :Cultivation ;
     owl:unionOf ( cultivationtype:701 cultivationtype:735 ) .
 

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -684,6 +684,12 @@ cultivationtype:154 a owl:Class ;
         "Broccoli"@it ;
     rdfs:subClassOf cultivationtype:324 .
 
+cultivationtype:156 a owl:Class ;
+    schema:name "Jungreben"@de,
+        "jeune vigne"@fr,
+        "Ceppi giovani"@it ;
+    rdfs:subClassOf cultivationtype:4 .
+
 cultivationtype:157 a owl:Class ;
     schema:name "Bohnenkraut"@de,
         "sarriette"@fr,
@@ -837,6 +843,12 @@ cultivationtype:211 a owl:Class ;
         "rhubarbe"@fr,
         "Rabarbaro"@it ;
     rdfs:subClassOf cultivationtype:120 .
+
+cultivationtype:213 a owl:Class ;
+    schema:name "Ertragsreben"@de,
+        "vigne en production"@fr,
+        "Vite in produzione"@it ;
+    rdfs:subClassOf cultivationtype:4 .
 
 cultivationtype:215 a owl:Class ;
     schema:name "Erbsen mit Hülsen"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -163,11 +163,10 @@ cultivationtype:1026 a owl:Class ;
     rdfs:subClassOf cultivationtype:521 .
 
 cultivationtype:1027 a owl:Class ;
-    rdfs:label "Zuckermais"@de,
-        "maïs sucré"@fr,
-        "Mais dolce"@it ;
-    rdfs:subClassOf cultivationtype:497 ;
-    :botanicalPlant taxon:ZEAMS .
+    rdfs:label "Eiweisserbsen"@de,
+        "pois protéagineux"@fr,
+        "pisello proteico"@it ;
+    rdfs:subClassOf cultivationtype:537 .
 
 cultivationtype:1028 a owl:Class ;
     rdfs:label "Ganzpflanzen-Sorghum"@de ;
@@ -237,11 +236,133 @@ cultivationtype:1039 a owl:Class ;
         "Colza primaverile"@it ;
     rdfs:subClassOf cultivationtype:494 .
 
+cultivationtype:1040 a owl:Class ;
+    rdfs:label "Kiwi"@de,
+        "Kiwi"@fr,
+        "Kiwi"@it ;
+    rdfs:subClassOf cultivationtype:731 .
+
+cultivationtype:1041 a owl:Class ;
+    rdfs:label "Kiwi, hoher Ertrag"@de,
+        "Kiwi, rendement élevé"@fr,
+        "Kiwi, resa elevata"@it ;
+    rdfs:subClassOf cultivationtype:731 .
+
+cultivationtype:1042 a owl:Class ;
+    rdfs:label "Kunstwiese intensiv"@de,
+        "Prairie artificielle intensive"@fr,
+        "Prato artificiale intensivo"@it ;
+    rdfs:subClassOf cultivationtype:601 .
+
+cultivationtype:1043 a owl:Class ;
+    rdfs:label "Kohlrabi (geschützter Anbau)"@de,
+        "Chou-rave (culture protégée)"@fr,
+        "Cavolo rapa (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:86 cultivationtype:23 ) .
+
+cultivationtype:1044 a owl:Class ;
+    rdfs:label "Verarbeitungskohlrabi"@de,
+        "Chou-rave d'industrie"@fr,
+        "Cavolo rapa da industria"@it ;
+    owl:intersectionOf ( cultivationtype:86 cultivationtype:546 ) .
+
+cultivationtype:1045 a owl:Class ;
+    rdfs:label "Ölhanf"@de,
+        "Chanvre oléagineux"@fr,
+        "Canapa da olio"@it ;
+    rdfs:subClassOf cultivationtype:575 .
+
+cultivationtype:1046 a owl:Class ;
+    rdfs:label "Frauenmantel"@de,
+        "Alchémille"@fr,
+        "Alchemilla"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
+cultivationtype:1047 a owl:Class ;
+    rdfs:label "Lauch, früh gepflanzt"@de,
+        "Poireau, plantation précoce"@fr,
+        "Porro, piantagione precoce"@it ;
+    rdfs:subClassOf cultivationtype:323 .
+
+cultivationtype:1048 a owl:Class ;
+    rdfs:label "Lauch, spät gepflanzt"@de,
+        "Poireau, plantation tardive"@fr,
+        "Porro, piantagione tardiva"@it ;
+    rdfs:subClassOf cultivationtype:323 .
+
+cultivationtype:1049 a owl:Class ;
+    rdfs:label "Lauch (geschützter Anbau)"@de,
+        "Poireau (culture protégée)"@fr,
+        "Porro (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:323 cultivationtype:7 ) .
+
 cultivationtype:105 a owl:Class ;
     rdfs:label "Lactuca-Salate"@de,
         "salades lactuca"@fr,
         "Insalate del genere Lactuca"@it ;
     rdfs:subClassOf cultivationtype:320 .
+
+cultivationtype:1050 a owl:Class ;
+    rdfs:label "Lauch, gesät"@de,
+        "Poireau, semé"@fr,
+        "Porro, seminato"@it ;
+    rdfs:subClassOf cultivationtype:323 .
+
+cultivationtype:1051 a owl:Class ;
+    rdfs:label "Lauch, gepflanzt, Überwinterung"@de,
+        "Poireau, planté, hivernage"@fr,
+        "Porro, piantato, svernamento"@it ;
+    rdfs:subClassOf cultivationtype:323 .
+
+cultivationtype:1052 a owl:Class ;
+    rdfs:label "Kleesamenproduktion"@de,
+        "Production de semences de trèfle"@fr,
+        "Produzione di sementi di trifoglio"@it ;
+    rdfs:subClassOf cultivationtype:631 .
+
+cultivationtype:1053 a owl:Class ;
+    rdfs:label "Gründüngung Leguminosen (Freilandgemüse)"@de,
+        "Engrais vert légumineuses (légumes de plein champ)"@fr,
+        "Sovescio leguminose (ortaggi di pieno campo)"@it ;
+    rdfs:subClassOf cultivationtype:15,
+        cultivationtype:24 .
+
+cultivationtype:1054 a owl:Class ;
+    rdfs:label "Zitronenmelisse"@de,
+        "Mélisse citronnelle"@fr,
+        "Melissa"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
+cultivationtype:1055 a owl:Class ;
+    rdfs:label "Indianernessel"@de,
+        "Monarde"@fr,
+        "Monarda"@it ;
+    schema:alternateName "Rosenmelisse"@de ;
+    rdfs:subClassOf cultivationtype:706 .
+
+cultivationtype:1056 a owl:Class ;
+    rdfs:label "Verarbeitungsbohnen"@de,
+        "Haricots d'industrie"@fr,
+        "Fagioli da industria"@it ;
+    owl:intersectionOf ( cultivationtype:476 cultivationtype:546 ) .
+
+cultivationtype:1057 a owl:Class ;
+    rdfs:label "Blattsalate (geschützter Anbau)"@de,
+        "Laitues (culture protégée)"@fr,
+        "Insalate a foglie (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:103 cultivationtype:7 ) .
+
+cultivationtype:1058 a owl:Class ;
+    rdfs:label "Kopfsalat, Eisbergsalat, Lollo (geschützter Anbau)"@de,
+        "Laitue pommée, iceberg, lollo (culture protégée)"@fr,
+        "Lattuga cappuccio, iceberg, lollo (coltura protetta)"@it ;
+    rdfs:subClassOf cultivationtype:1057 .
+
+cultivationtype:1059 a owl:Class ;
+    rdfs:label "Andorn"@de,
+        "Marrube blanc"@fr,
+        "Marrubio"@it ;
+    rdfs:subClassOf cultivationtype:706 .
 
 cultivationtype:106 a owl:Class ;
     rdfs:label "Basilikum"@de,
@@ -249,17 +370,229 @@ cultivationtype:106 a owl:Class ;
         "Basilico"@it ;
     rdfs:subClassOf cultivationtype:67 .
 
+cultivationtype:1060 a owl:Class ;
+    rdfs:label "Majoran"@de,
+        "Marjolaine"@fr,
+        "Maggiorana"@it ;
+    rdfs:subClassOf cultivationtype:705 .
+
+cultivationtype:1061 a owl:Class ;
+    rdfs:label "Eibisch"@de,
+        "Guimauve"@fr,
+        "Altea"@it ;
+    rdfs:subClassOf cultivationtype:705 .
+
+cultivationtype:1062 a owl:Class ;
+    rdfs:label "Eisenkraut"@de,
+        "Verveine"@fr,
+        "Verbena"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
+cultivationtype:1063 a owl:Class ;
+    rdfs:label "Kenaf"@de,
+        "Kénaf"@fr,
+        "Kenaf"@it ;
+    rdfs:subClassOf cultivationtype:552 .
+
+cultivationtype:1064 a owl:Class ;
+    rdfs:label "Gründüngung Nichtleguminosen (Freilandgemüse)"@de,
+        "Engrais vert non-légumineuses (légumes de plein champ)"@fr,
+        "Sovescio non leguminose (ortaggi di pieno campo)"@it ;
+    rdfs:subClassOf cultivationtype:24 ;
+    owl:disjointWith cultivationtype:1053 .
+
+cultivationtype:1065 a owl:Class ;
+    rdfs:label "Baumschulen"@de,
+        "Pépinières"@fr,
+        "Vivai"@it ;
+    rdfs:subClassOf :Cultivation ;
+    owl:unionOf ( cultivationtype:722 cultivationtype:723 cultivationtype:724 ) .
+
+cultivationtype:1066 a owl:Class ;
+    rdfs:label "Baumschulen für den Erwerbsobstbau (hohe Pflanzendichte)"@de,
+        "Pépinières pour l'arboriculture fruitière professionnelle (haute densité)"@fr,
+        "Vivai per la frutticoltura professionale (ad alta densità)"@it ;
+    rdfs:subClassOf cultivationtype:1065 .
+
+cultivationtype:1067 a owl:Class ;
+    rdfs:label "Baumschulen (ohne Erwerbsobstbau mit hoher Pflanzendichte)"@de,
+        "Pépinières (sans arboriculture fruitière professionnelle à haute densité)"@fr,
+        "Vivai (esclusa frutticoltura professionale ad alta densità)"@it ;
+    rdfs:subClassOf cultivationtype:1065 ;
+    owl:disjointWith cultivationtype:1066 .
+
+cultivationtype:1068 a owl:Class ;
+    rdfs:label "Orangenminze"@de,
+        "Menthe orange"@fr,
+        "Menta arancio"@it ;
+    schema:alternateName "Bergamottminze"@de ;
+    rdfs:subClassOf cultivationtype:706 .
+
+cultivationtype:1069 a owl:Class ;
+    rdfs:label "Oregano"@de,
+        "Origan"@fr,
+        "Origano"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
 cultivationtype:107 a owl:Class ;
     rdfs:label "Karotten"@de,
         "carotte"@fr,
         "Carote"@it ;
     rdfs:subClassOf cultivationtype:327 .
 
+cultivationtype:1070 a owl:Class ;
+    rdfs:label "Viola"@de,
+        "Pensée"@fr,
+        "Viola del pensiero"@it ;
+    schema:alternateName "Stiefmütterchen"@de ;
+    rdfs:subClassOf cultivationtype:554 .
+
+cultivationtype:1071 a owl:Class ;
+    rdfs:label "Paprika, Bodenkulturen (geschützter Anbau)"@de,
+        "Poivron, culture au sol (culture protégée)"@fr,
+        "Peperone, coltura su suolo (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:811 cultivationtype:335 ) .
+
+cultivationtype:1072 a owl:Class ;
+    rdfs:label "Petersilie, je weiterem Schnitt"@de,
+        "Persil, par coupe supplémentaire"@fr,
+        "Prezzemolo, per ogni taglio supplementare"@it ;
+    rdfs:subClassOf cultivationtype:311 .
+
+cultivationtype:1073 a owl:Class ;
+    rdfs:label "Petersilie, bis zum ersten Schnitt"@de,
+        "Persil, jusqu'à la première coupe"@fr,
+        "Prezzemolo, fino al primo taglio"@it ;
+    rdfs:subClassOf cultivationtype:311 .
+
+cultivationtype:1074 a owl:Class ;
+    rdfs:label "Kefen"@de,
+        "Mange-tout"@fr,
+        "Taccole"@it ;
+    schema:alternateName "Zuckerschoten"@de ;
+    rdfs:subClassOf cultivationtype:191 .
+
+cultivationtype:1075 a owl:Class ;
+    rdfs:label "Erbsen, Kefen"@de,
+        "Pois, mange-tout"@fr,
+        "Piselli, taccole"@it ;
+    rdfs:subClassOf cultivationtype:15 ;
+    owl:unionOf ( cultivationtype:191 cultivationtype:1074 ) .
+
+cultivationtype:1076 a owl:Class ;
+    rdfs:label "Verarbeitungserbsen"@de,
+        "Pois d'industrie"@fr,
+        "Piselli da industria"@it ;
+    owl:intersectionOf ( cultivationtype:191 cultivationtype:546 ) .
+
+cultivationtype:1077 a owl:Class ;
+    rdfs:label "Pfirsichanlage, hoher Ertrag"@de,
+        "Verger de pêchers, rendement élevé"@fr,
+        "Pescheto, resa elevata"@it ;
+    rdfs:subClassOf cultivationtype:31 .
+
+cultivationtype:1078 a owl:Class ;
+    rdfs:label "Pfirsichanlage (ohne Ertragsspezifizierung)"@de,
+        "Verger de pêchers (sans spécification de rendement)"@fr,
+        "Pescheto (senza specifica di resa)"@it ;
+    rdfs:subClassOf cultivationtype:31 .
+
+cultivationtype:1079 a owl:Class ;
+    rdfs:label "Gurken, Essiggurken"@de,
+        "Concombres, cornichons"@fr,
+        "Cetrioli, cetriolini"@it ;
+    rdfs:subClassOf cultivationtype:235 ;
+    owl:unionOf ( cultivationtype:32 cultivationtype:207 ) .
+
+cultivationtype:1080 a owl:Class ;
+    rdfs:label "Intensive Weiden und Mähweiden"@de ;
+    schema:alternateName "Weide (Mäh-) intensiv"@de ;
+    rdfs:subClassOf cultivationtype:616 .
+
+cultivationtype:1081 a owl:Class ;
+    rdfs:label "Stangenbohne (geschützter Anbau)"@de,
+        "Haricot à rames (culture protégée)"@fr,
+        "Fagiolo rampicante (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:201 cultivationtype:7 ) .
+
+cultivationtype:1082 a owl:Class ;
+    rdfs:label "Zwetschgenanlage, hoher Ertrag"@de,
+        "Verger de pruniers, rendement élevé"@fr,
+        "Prugneto/Susineto, resa elevata"@it ;
+    rdfs:subClassOf cultivationtype:113 .
+
+cultivationtype:1083 a owl:Class ;
+    rdfs:label "Zwetschgenanlage (ohne Ertragsspezifizierung)"@de,
+        "Verger de pruniers (sans spécification de rendement)"@fr,
+        "Prugneto/Susineto (senza specifica di resa)"@it ;
+    rdfs:subClassOf cultivationtype:113 .
+
+cultivationtype:1084 a owl:Class ;
+    rdfs:label "Spitzwegerich"@de,
+        "Plantain lancéolé"@fr,
+        "Piantaggine lanciuola"@it ;
+    rdfs:subClassOf cultivationtype:35 .
+
+cultivationtype:1085 a owl:Class ;
+    rdfs:label "Mittelintensive Weiden und Mähweiden"@de,
+        "Pâturages et pâturages de fauche moyennement intensifs"@fr,
+        "Pascoli e pascoli da sfalcio medio-intensivi"@it ;
+    schema:alternateName "Weide (Mäh-) mittelintensiv"@de ;
+    rdfs:subClassOf cultivationtype:616 .
+
+cultivationtype:1086 a owl:Class ;
+    rdfs:label "Schlüsselblume (ganze Pflanze)"@de,
+        "Primevère (plante entière)"@fr,
+        "Primula (pianta intera)"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
+cultivationtype:1087 a owl:Class ;
+    rdfs:label "Kernobstanlage, hoher Ertrag"@de,
+        "Verger de fruits à pépins, rendement élevé"@fr,
+        "Frutteto a granelli, resa elevata"@it ;
+    rdfs:subClassOf cultivationtype:309 .
+
+cultivationtype:1088 a owl:Class ;
+    rdfs:label "Kernobstanlage (ohne Ertragsspezifizierung)"@de,
+        "Verger de fruits à pépins (sans spécification de rendement)"@fr,
+        "Frutteto a granelli (senza specifica di resa)"@it ;
+    rdfs:subClassOf cultivationtype:309 .
+
+cultivationtype:1089 a owl:Class ;
+    rdfs:label "Frühkartoffeln"@de,
+        "Pommes de terre hâtives"@fr,
+        "Patate novelle"@it ;
+    rdfs:subClassOf cultivationtype:524 .
+
 cultivationtype:109 a owl:Class ;
     rdfs:label "Kerbel"@de,
         "cerfeuil"@fr,
         "Cerfoglio"@it ;
     rdfs:subClassOf cultivationtype:67 .
+
+cultivationtype:1090 a owl:Class ;
+    rdfs:label "Speise- und Verarbeitungskartoffeln"@de,
+        "Pommes de terre de consommation et d'industrie"@fr,
+        "Patate da consumo e da industria"@it ;
+    rdfs:subClassOf cultivationtype:524 .
+
+cultivationtype:1091 a owl:Class ;
+    rdfs:label "Pfefferminze"@de,
+        "Menthe poivrée"@fr,
+        "Menta piperita"@it ;
+    rdfs:subClassOf cultivationtype:299 .
+
+cultivationtype:1092 a owl:Class ;
+    rdfs:label "Petersilie (geschützter Anbau)"@de,
+        "Persil (culture protégée)"@fr,
+        "Prezzemolo (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:311 cultivationtype:7 ) .
+
+cultivationtype:1093 a owl:Class ;
+    rdfs:label "Kürbis"@de,
+        "Courge"@fr,
+        "Zucca"@it ;
+    rdfs:subClassOf cultivationtype:235 .
 
 cultivationtype:110 a owl:Class ;
     rdfs:label "Artischocken"@de,
@@ -493,7 +826,7 @@ cultivationtype:166 a owl:Class ;
     rdfs:label "Speisekürbisse (ungeniessbare Schale)"@de,
         "courges (écorce non comestible)"@fr,
         "Zucche (buccia non commestibile)"@it ;
-    rdfs:subClassOf cultivationtype:235 .
+    rdfs:subClassOf cultivationtype:1093 .
 
 cultivationtype:17 a owl:Class ;
     rdfs:label "Hackfrüchte"@de,
@@ -618,6 +951,7 @@ cultivationtype:207 a owl:Class ;
     rdfs:label "Einlegegurken"@de,
         "cornichons"@fr,
         "cetrioli per conserva"@it ;
+    schema:alternateName "Essiggurken"@de ;
     rdfs:subClassOf cultivationtype:32 .
 
 cultivationtype:208 a owl:Class ;
@@ -696,7 +1030,7 @@ cultivationtype:228 a owl:Class ;
     rdfs:label "Ölkürbisse"@de,
         "courges oléagineuses"@fr,
         "Zucca da olio"@it ;
-    rdfs:subClassOf cultivationtype:235 .
+    rdfs:subClassOf cultivationtype:1093 .
 
 cultivationtype:229 a owl:Class ;
     rdfs:label "Schnittmangold"@de,
@@ -839,6 +1173,7 @@ cultivationtype:260 a owl:Class ;
     rdfs:label "Nüsslisalat"@de,
         "mâche, rampon"@fr,
         "Valerianella"@it ;
+    schema:alternateName "Feldsalat"@de ;
     rdfs:subClassOf cultivationtype:209 .
 
 cultivationtype:263 a owl:Class ;
@@ -1014,6 +1349,7 @@ cultivationtype:306 a owl:Class ;
         "Turnip-rooted parsley"@en,
         "persil à grosse racine"@fr,
         "Prezzemolo tuberoso"@it ;
+    schema:alternateName "Petersilienwurzel"@de ;
     rdfs:subClassOf cultivationtype:327 .
 
 cultivationtype:308 a owl:Class ;
@@ -1149,13 +1485,14 @@ cultivationtype:4 a owl:Class ;
     rdfs:label "Reben"@de,
         "Vignobles"@fr,
         "Vigna"@it ;
-    rdfs:subClassOf :Cultivation .
+    rdfs:subClassOf :Cultivation ;
+    owl:unionOf ( cultivationtype:701 cultivationtype:735 ) .
 
 cultivationtype:40 a owl:Class ;
     rdfs:label "Kürbisse mit geniessbarer Schale"@de,
         "courges à peau comestible"@fr,
         "Zucche con buccia commestibile"@it ;
-    rdfs:subClassOf cultivationtype:235 .
+    rdfs:subClassOf cultivationtype:1093 .
 
 cultivationtype:41 a owl:Class ;
     rdfs:label "Birne / Nashi"@de,
@@ -1229,6 +1566,7 @@ cultivationtype:479 a owl:Class ;
     rdfs:label "Liebstöckel"@de,
         "livèche"@fr,
         "Levistico"@it ;
+    schema:alternateName "Maggikraut"@de ;
     rdfs:subClassOf cultivationtype:67 .
 
 cultivationtype:48 a owl:Class ;
@@ -1550,7 +1888,7 @@ cultivationtype:539 a owl:Class ;
     rdfs:label "Ölkürbisse"@de,
         "Courges à huile"@fr,
         "Zucche per l’estrazione di olio"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1093 .
 
 cultivationtype:540 a owl:Class ;
     rdfs:label "Kichererbsen"@de,
@@ -1866,6 +2204,9 @@ cultivationtype:611 a owl:Class ;
     rdfs:label "Extensiv genutzte Wiesen (ohne Weiden)"@de,
         "Prairies extensives (sans les pâturages)"@fr,
         "Prati estensivi (senza pascoli)"@it ;
+    rdfs:comment "Extensiv genutzte Wiesen werden nicht gedüngt und spät geschnitten, wie zum Beispiel Halbtrocken- oder Trespenwiesen. Sie stellen das artenreichste Grünland der Schweiz dar."@de,
+        "Les prairies exploitées de manière extensive ne sont pas fertilisées et sont fauchées tardivement, comme par exemple les prairies mi-sèches ou à brome. Elles représentent les herbages les plus riches en espèces de Suisse."@fr,
+        "I prati sfruttati in modo estensivo non vengono concimati e vengono falciati tardi, come ad esempio i prati semi-aridi o a brometo. Rappresentano le praterie più ricche di specie della Svizzera."@it ;
     rdfs:subClassOf cultivationtype:2 ;
     :intensity :21 .
 
@@ -1873,6 +2214,9 @@ cultivationtype:612 a owl:Class ;
     rdfs:label "Wenig intensiv genutzte Wiesen (ohne Weiden)"@de,
         "Prairies peu intensives (sans les pâturages)"@fr,
         "Prati poco intensivi (senza pascoli)"@it ;
+    rdfs:comment "Wenig intensiv genutzte Wiesen sind leicht gedüngte, spät geschnittene Wiesen wie zum Beispiel Fromental- oder Goldhaferwiesen"@de,
+        "Les prairies peu intensives sont des prairies légèrement fertilisées et fauchées tardivement, comme par exemple les prairies à fromental ou à avoine dorée."@fr,
+        "I prati poco intensivi sono prati leggermente concimati e falciati tardi, come ad esempio i prati a fromental o ad avena bionda."@it ;
     rdfs:subClassOf cultivationtype:2 ;
     :intensity :22 .
 
@@ -1987,10 +2331,8 @@ cultivationtype:7 a owl:Class ;
     rdfs:subClassOf :Cultivation .
 
 cultivationtype:701 a owl:Class ;
-    rdfs:label "Reben"@de,
-        "Vignes"@fr,
-        "Vigna"@it ;
-    rdfs:subClassOf cultivationtype:4 .
+    rdfs:label "Reben (ohne regionsspezifische Biodiversitätsförderflächen)"@de ;
+    owl:disjointWith cultivationtype:735 .
 
 cultivationtype:702 a owl:Class ;
     rdfs:label "Obstanlagen (Äpfel)"@de,
@@ -2140,8 +2482,7 @@ cultivationtype:731 a owl:Class ;
 cultivationtype:735 a owl:Class ;
     rdfs:label "Reben (regionsspezifische Biodiversitätsförderflächen)"@de,
         "Vignes (surfaces de promotion de la biodiversité spécifiques à la ré-gion)"@fr,
-        "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:4 .
+        "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it .
 
 cultivationtype:75 a owl:Class ;
     rdfs:label "Portulak"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -785,6 +785,12 @@ cultivationtype:154 a owl:Class ;
         "Broccoli"@it ;
     rdfs:subClassOf cultivationtype:324 .
 
+cultivationtype:156 a owl:Class ;
+    rdfs:label "Jungreben"@de,
+        "jeune vigne"@fr,
+        "Ceppi giovani"@it ;
+    rdfs:subClassOf cultivationtype:4 .
+
 cultivationtype:157 a owl:Class ;
     rdfs:label "Bohnenkraut"@de,
         "sarriette"@fr,
@@ -977,6 +983,12 @@ cultivationtype:211 a owl:Class ;
         "rhubarbe"@fr,
         "Rabarbaro"@it ;
     rdfs:subClassOf cultivationtype:120 .
+
+cultivationtype:213 a owl:Class ;
+    rdfs:label "Ertragsreben"@de,
+        "vigne en production"@fr,
+        "Vite in produzione"@it ;
+    rdfs:subClassOf cultivationtype:4 .
 
 cultivationtype:215 a owl:Class ;
     rdfs:label "Erbsen mit Hülsen"@de,


### PR DESCRIPTION
## Changes

- Model "vines" as a union of the two disjoint classes from AGIS `cultivationtype:701` and `cultivationtype:735`.
- Add and map all sorts from the Swiss registry of plant protection products SRPPP.