### PR TITLE
Map last PSM crops possible

### DIFF
--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -523,7 +523,7 @@ psm:104 a cube:Observation ;
         "pavot"@fr,
         "Papavero"@it ;
     schema:version 0 ;
-    :cultivationType cultivationtype:104 .
+    :cultivationType cultivationtype:566 .
 
 psm:105 a cube:Observation ;
     schema:identifier "33686F38-1E1A-4698-81E4-C40EE4494EF3"^^xsd:ID ;

--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -523,7 +523,7 @@ psm:104 a cube:Observation ;
         "pavot"@fr,
         "Papavero"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:104 .
 
 psm:105 a cube:Observation ;
     schema:identifier "33686F38-1E1A-4698-81E4-C40EE4494EF3"^^xsd:ID ;
@@ -820,7 +820,7 @@ psm:134 a cube:Observation ;
         "culture maraîchère en général"@fr,
         "Orticoltura in generale"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:22 .
 
 psm:135 a cube:Observation ;
     schema:identifier "B82B5C60-02CB-4B7A-B3D3-A4CA34A809C3"^^xsd:ID ;
@@ -883,7 +883,7 @@ psm:140 a cube:Observation ;
         "camérisier bleu"@fr,
         "Caprifoglio turchino"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:140 .
 
 psm:141 a cube:Observation ;
     schema:identifier "8DB1A579-6BAC-4DCB-8026-E79B65D3BD3A"^^xsd:ID ;
@@ -1102,7 +1102,7 @@ psm:162 a cube:Observation ;
         "pépinières forestières"@fr,
         "Vivai forestali"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:162 .
 
 psm:163 a cube:Observation ;
     schema:identifier "449A5380-96E3-4C3F-AB31-7CB3D0579561"^^xsd:ID ;
@@ -1118,7 +1118,7 @@ psm:164 a cube:Observation ;
     schema:name "allg. Weinbau"@de,
         "domaine app. vignes"@fr ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:4 .
 
 psm:165 a cube:Observation ;
     schema:identifier "56AF3EA3-01F4-4F10-B240-7EF4BE1C1CCE"^^xsd:ID ;
@@ -1201,7 +1201,7 @@ psm:172 a cube:Observation ;
         "Laurier"@fr,
         "Alloro"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:172 .
 
 psm:173 a cube:Observation ;
     schema:identifier "4DD550C5-15BB-4D52-98BD-6770972575F0"^^xsd:ID ;
@@ -1218,7 +1218,7 @@ psm:174 a cube:Observation ;
         "sorbier des oiseleurs"@fr,
         "Sorbo degli ucellatori"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:174 .
 
 psm:175 a cube:Observation ;
     schema:identifier "46901564-D096-4323-AE81-C93831AFEC64"^^xsd:ID ;
@@ -1686,7 +1686,7 @@ psm:220 a cube:Observation ;
         "Maïs"@fr,
         "Mais"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:497 .
 
 psm:221 a cube:Observation ;
     schema:identifier "C5188A42-9C79-4110-B1E8-AEE9D6078BEA"^^xsd:ID ;
@@ -1993,7 +1993,7 @@ psm:251 a cube:Observation ;
         "pommes de terre pour la production de plants"@fr,
         "Patate per la produzione di tuberi-seme"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:411 .
 
 psm:252 a cube:Observation ;
     schema:identifier "6D45EAF5-D29C-48AB-A212-91C67357E898"^^xsd:ID ;
@@ -2093,7 +2093,7 @@ psm:261 a cube:Observation ;
         "Orpin rose"@fr,
         "Rhodiola rosea"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:261 .
 
 psm:262 a cube:Observation ;
     schema:identifier "9650E36A-38F4-4375-9594-25785BACE1DC"^^xsd:ID ;
@@ -2148,7 +2148,7 @@ psm:267 a cube:Observation ;
         "Baies de Goji"@fr,
         "Bacche di Goji"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:267 .
 
 psm:268 a cube:Observation ;
     schema:identifier "730AACDC-B956-493D-8148-7520019CE0BC"^^xsd:ID ;
@@ -2328,7 +2328,7 @@ psm:285 a cube:Observation ;
         "arboriculture en général"@fr,
         "Frutticoltura in generale"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:5 .
 
 psm:286 a cube:Observation ;
     schema:identifier "E58E502E-BECD-44CB-96A2-3A6771D8A7B7"^^xsd:ID ;
@@ -2345,7 +2345,7 @@ psm:287 a cube:Observation ;
         "mélisse"@fr,
         "Melissa"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:287 .
 
 psm:288 a cube:Observation ;
     schema:identifier "D63D73AC-87B1-41F7-82AC-D1DFF12F6704"^^xsd:ID ;
@@ -2414,7 +2414,7 @@ psm:294 a cube:Observation ;
         "Cerfeuil tubéreux"@fr,
         "Cerfoglio bulboso"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:294 .
 
 psm:295 a cube:Observation ;
     schema:identifier "710CC0C8-B138-4B31-9975-4DA04AF67792"^^xsd:ID ;
@@ -2431,7 +2431,7 @@ psm:296 a cube:Observation ;
         "sylviculture en général"@fr,
         "Selvicoltura in generale"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:901 .
 
 psm:297 a cube:Observation ;
     schema:identifier "399AC89E-29BB-44AD-8B1F-0B2F327D5230"^^xsd:ID ;
@@ -2551,7 +2551,7 @@ psm:307 a cube:Observation ;
         "pois chiche"@fr,
         "cece"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:307 .
 
 psm:308 a cube:Observation ;
     schema:identifier "14B19DFD-331F-4C30-8724-8EDDF8E2D0D4"^^xsd:ID ;
@@ -2613,7 +2613,7 @@ psm:313 a cube:Observation ;
     schema:name "allg. Forstwirtschaft"@de,
         "domaine app. sylviculture"@fr ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:901 .
 
 psm:314 a cube:Observation ;
     schema:identifier "3447F4C9-2E90-437F-A240-0462AFEDF2B5"^^xsd:ID ;
@@ -2632,7 +2632,7 @@ psm:315 a cube:Observation ;
         "chrysanthème"@fr,
         "Crisantemo"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:315 .
 
 psm:316 a cube:Observation ;
     schema:identifier "1DD3F253-4B23-4B69-BFB1-1C24CE7D5508"^^xsd:ID ;
@@ -2656,7 +2656,7 @@ psm:318 a cube:Observation ;
         "ranunculus"@fr,
         "ranuncolo"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:318 .
 
 psm:319 a cube:Observation ;
     schema:identifier "01AFF6EB-9C8D-4D0D-B225-0BA07B59A72F"^^xsd:ID ;
@@ -2763,7 +2763,7 @@ psm:329 a cube:Observation ;
         "culture ornementale en général"@fr,
         "Coltivazione piante ornam. in generale"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:329 .
 
 psm:33 a cube:Observation ;
     schema:identifier "309E5D09-3084-40C6-88F2-D4A14345136C"^^xsd:ID ;
@@ -2781,7 +2781,7 @@ psm:330 a cube:Observation ;
         "fenouil aromatique"@fr,
         "Finocchio aromatico"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:330 .
 
 psm:331 a cube:Observation ;
     schema:identifier "8AFA14F8-CCE3-4012-BD12-9D690EBAE1AD"^^xsd:ID ;
@@ -2935,14 +2935,14 @@ psm:43 a cube:Observation ;
         "josta"@fr,
         "Josta"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:43 .
 
 psm:44 a cube:Observation ;
     schema:identifier "FD7AB34C-F432-445D-9440-F44FDAB8422C"^^xsd:ID ;
     schema:name "allg. Wiesen und Weiden"@de,
         "domaine app. prairies et paturages"@fr ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:116 .
 
 psm:45 a cube:Observation ;
     schema:identifier "D95CD842-A5BC-4DAA-935D-F009DA7BA748"^^xsd:ID ;
@@ -3194,7 +3194,7 @@ psm:7 a cube:Observation ;
         "bulbes ornementaux"@fr,
         "Bulbi ornamentali"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:409 .
 
 psm:70 a cube:Observation ;
     schema:identifier "D3D49C53-8EBC-4DAC-9C4C-B988AA162F7D"^^xsd:ID ;
@@ -3204,7 +3204,7 @@ psm:70 a cube:Observation ;
         "Épeautre"@fr,
         "Spelta"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:516 .
 
 psm:71 a cube:Observation ;
     schema:identifier "D3D90BE6-0924-4844-98FB-52C4D7F21A38"^^xsd:ID ;
@@ -3232,7 +3232,7 @@ psm:73 a cube:Observation ;
         "Céréales"@fr,
         "Cereali"@it ;
     schema:version 0 ;
-    :cultivationType cultivationtype:14 .
+    :cultivationType cultivationtype:1033 .
 
 psm:74 a cube:Observation ;
     schema:identifier "C3A65223-4A74-461D-AE47-0E8F7223E0C2"^^xsd:ID ;
@@ -3241,7 +3241,7 @@ psm:74 a cube:Observation ;
         "alfalfa"@fr,
         "Alfalfa"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:68 .
 
 psm:75 a cube:Observation ;
     schema:identifier "8A00630A-32FC-4B5A-8171-EC0F41D39F48"^^xsd:ID ;
@@ -3323,7 +3323,7 @@ psm:82 a cube:Observation ;
         "Chanvre"@fr,
         "Canapa"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:535 .
 
 psm:83 a cube:Observation ;
     schema:identifier "E981BFA6-288D-4EA6-B81B-4F610611EB36"^^xsd:ID ;
@@ -3331,7 +3331,7 @@ psm:83 a cube:Observation ;
         "plantes médicinales"@fr,
         "erbe medicinali"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:83 .
 
 psm:84 a cube:Observation ;
     schema:identifier "EB820B26-DE4E-4AF4-8BA3-46844F045306"^^xsd:ID ;
@@ -3411,7 +3411,7 @@ psm:91 a cube:Observation ;
         "amélavier commun"@fr,
         "Pero corvino"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:91 .
 
 psm:92 a cube:Observation ;
     schema:identifier "9A9333CA-AD6C-459D-9AFF-B8E8FB2FF8D4"^^xsd:ID ;
@@ -3456,7 +3456,7 @@ psm:96 a cube:Observation ;
         "pommes de terre"@fr,
         "Patate"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:410 .
 
 psm:97 a cube:Observation ;
     schema:identifier "F171615D-81A1-4654-BF30-BF51620DFFB9"^^xsd:ID ;

--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -1253,7 +1253,7 @@ psm:178 a cube:Observation ;
         "toutes les cultures"@fr,
         "In generale"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType :Cultivation .
 
 psm:179 a cube:Observation ;
     schema:identifier "62BF86AE-FD69-4F95-A72C-1D57AF1DCD99"^^xsd:ID ;
@@ -3114,7 +3114,7 @@ psm:61 a cube:Observation ;
     schema:name "allg. Obstbau"@de,
         "domaine app. arboriculture"@fr ;
     schema:version 0 ;
-    :cultivationType cultivationtype:730 .
+    :cultivationType cultivationtype:5 .
 
 psm:62 a cube:Observation ;
     schema:identifier "E59545AD-3331-4E3D-B58D-9F67833C060B"^^xsd:ID ;

--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -621,7 +621,7 @@ psm:114 a cube:Observation ;
         "surfaces herbagères"@fr,
         "Superficie inerbita"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:114 .
 
 psm:115 a cube:Observation ;
     schema:identifier "1F004DAA-89AD-4A9D-A172-95D24B8A45FA"^^xsd:ID ;

--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -2371,7 +2371,7 @@ psm:29 a cube:Observation ;
         "anémone"@fr,
         "Anemone"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:408 .
 
 psm:290 a cube:Observation ;
     schema:identifier "EB0C465C-50B7-4DC0-914B-ABE4C284A907"^^xsd:ID ;

--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -1541,7 +1541,7 @@ psm:206 a cube:Observation ;
         "plantain lancéolé"@fr,
         "piantaggine lanciuola"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:206 .
 
 psm:207 a cube:Observation ;
     schema:identifier "238AB652-AD62-4703-A74B-7550C693ED6E"^^xsd:ID ;
@@ -2102,7 +2102,7 @@ psm:262 a cube:Observation ;
         "actée à grappe"@fr,
         "actaea racemosa"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:262 .
 
 psm:263 a cube:Observation ;
     schema:identifier "BA6FCA8F-68B8-4408-A267-2546B1FA5764"^^xsd:ID ;
@@ -2267,7 +2267,7 @@ psm:279 a cube:Observation ;
         "digitale lanifère"@fr,
         "Digitale lanata"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:279 .
 
 psm:28 a cube:Observation ;
     schema:identifier "36D9AFE2-7506-48CE-BA39-EFD54535294A"^^xsd:ID ;
@@ -2925,7 +2925,7 @@ psm:42 a cube:Observation ;
         "Patate douce"@fr,
         "Patata dolce"@it ;
     schema:version 2 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:1137 .
 
 psm:43 a cube:Observation ;
     schema:identifier "FFDDDA7D-B340-473C-94F4-841272B602FA"^^xsd:ID ;
@@ -3296,7 +3296,7 @@ psm:8 a cube:Observation ;
         "Cerfeuil musqué"@fr,
         "finocchiella"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:412 .
 
 psm:80 a cube:Observation ;
     schema:identifier "D18572C7-A270-4AA7-B766-48D62C5E9AB7"^^xsd:ID ;
@@ -3304,7 +3304,7 @@ psm:80 a cube:Observation ;
         "mûrier noir"@fr,
         "Moro nero"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:80 .
 
 psm:81 a cube:Observation ;
     schema:identifier "CA58ABAE-E494-4608-BE51-5FF49D853A03"^^xsd:ID ;
@@ -3376,7 +3376,7 @@ psm:88 a cube:Observation ;
         "pommes de terre de consommation et fourragère"@fr,
         "Patate da tavola e da foraggio"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:88 .
 
 psm:89 a cube:Observation ;
     schema:identifier "C883F887-6B72-4917-9385-7A757E5FD8D6"^^xsd:ID ;
@@ -3428,7 +3428,7 @@ psm:93 a cube:Observation ;
         "argousier"@fr,
         "Olivello spinoso"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:93 .
 
 psm:94 a cube:Observation ;
     schema:identifier "D36B92CB-136F-46C3-8217-10C3F86ECA12"^^xsd:ID ;

--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -2700,7 +2700,7 @@ psm:322 a cube:Observation ;
         "friche"@fr,
         "Terreno incolto"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:322 .
 
 psm:323 a cube:Observation ;
     schema:identifier "8DFDE2D1-C004-4C25-BF54-21CF7C815232"^^xsd:ID ;
@@ -3268,7 +3268,7 @@ psm:77 a cube:Observation ;
         "jachère"@fr,
         "Maggese"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:77 .
 
 psm:78 a cube:Observation ;
     schema:identifier "C9DB1105-33C7-44E8-92BA-9BBE5BA2BB3F"^^xsd:ID ;

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -241,7 +241,7 @@ cultivationtype:21 a owl:Class ;
     schema:name "Dauergrünfläche"@de ;
     schema:alternateName "Dauergrünland"@de ;
     schema:description "Als Dauergrünfläche gilt die mit Gräsern und Kräutern bewachsene Fläche ausserhalb der Sömmerungsflächen. Sie besteht seit mehr als sechs Jahren als Dauerwiese oder als Dauerweide (Art. 19 LBV)."@de ;
-    rdfs:subClassOf :Cultivation .
+    rdfs:subClassOf cultivationtype:114 .
 
 cultivationtype:22 a owl:Class ;
     schema:name "Gemüsebau"@de,
@@ -698,6 +698,12 @@ cultivationtype:113 a owl:Class ;
         "Prugno/Susino"@it ;
     owl:unionOf ( cultivationtype:259 cultivationtype:198 ) ;
     rdfs:subClassOf cultivationtype:704 .
+
+cultivationtype:114 a owl:Class ;
+    schema:name "Grünfläche"@de,
+        "surfaces herbagères"@fr,
+        "Superficie inerbita"@it ;
+    rdfs:subClassOf :Cultivation .
 
 cultivationtype:115 a owl:Class ;
     schema:name "Brassica napus-Rüben"@de,
@@ -2514,7 +2520,7 @@ cultivationtype:601 a owl:Class ;
     schema:name "Kunstwiesen (ohne Weiden)"@de,
         "Prairies artificielles (sans les pâturages)"@fr,
         "Prati artificiali (senza pascoli)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1, cultivationtype:114 .
 
 cultivationtype:602 a owl:Class ;
     schema:name "Übrige Kunstwiese, beitragsberechtigt"@de,
@@ -2523,7 +2529,7 @@ cultivationtype:602 a owl:Class ;
     schema:description "Übrige Kunstwiese, beitragsberechtigt (z.B. Schweineweide, Geflügelweide)"@de,
         "Autres prairies artificielles donnant droit aux contributions (p.ex. pâturages pour porcs et volaille)"@fr,
         "Altri prati artificiali avente diritto ai contributi (p.es. pascoli riservati ai suini e al pollame)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1, cultivationtype:114 .
 
 cultivationtype:611 a owl:Class ;
     schema:name "Extensiv genutzte Wiesen (ohne Weiden)"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -1629,6 +1629,14 @@ cultivationtype:407 a owl:Class ;
         "Bulbi di fiori"@it ;
     rdfs:subClassOf cultivationtype:329 .
 
+cultivationtype:408 a owl:Class ;
+    schema:name "Anemone"@de,
+        "anémone"@fr,
+        "Anemone"@it ;
+    rdfs:subClassOf cultivationtype:145,
+        cultivationtype:310,
+        cultivationtype:312 .
+
 cultivationtype:468 a owl:Class ;
     schema:name "Ackerbohne"@de,
         "féverole"@fr,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -638,12 +638,6 @@ cultivationtype:103 a owl:Class ;
         "Insalate a foglie (Asteracee)"@it ;
     rdfs:subClassOf cultivationtype:105 .
 
-cultivationtype:104 a owl:Class ;
-    schema:name "Mohn"@de,
-        "pavot"@fr,
-        "Papavero"@it ;
-    rdfs:subClassOf cultivationtype:1 .
-
 cultivationtype:105 a owl:Class ;
     schema:name "Lactuca-Salate"@de,
         "salades lactuca"@fr,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -823,7 +823,7 @@ cultivationtype:140 a owl:Class ;
         "Caprifoglio turchino"@it ;
     schema:alternateName "Maibeere"@de,
         "Haskap-Beere"@de ;
-    :cultivationType cultivationtype:1158 .
+    rdfs:subClassOf cultivationtype:1158 .
 
 cultivationtype:141 a owl:Class ;
     schema:name "Endivien und Blattzichorien"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -513,6 +513,13 @@ cultivationtype:79 a owl:Class ;
         "Graminacee per la produzione di sementi"@it ;
     rdfs:subClassOf cultivationtype:1 .
 
+cultivationtype:80 a owl:Class ;
+    schema:name "Schwarze Maulbeere"@de,
+        "Black mulberry"@en,
+        "mûrier noir"@fr,
+        "Moro nero"@it ;
+    rdfs:subClassOf cultivationtype:719 .
+
 cultivationtype:81 a owl:Class ;
     schema:name "Kopfkohle"@de,
         "choux pommés"@fr,
@@ -549,6 +556,13 @@ cultivationtype:87 a owl:Class ;
         "Cavolo piuma"@it ;
     rdfs:subClassOf cultivationtype:20 .
 
+cultivationtype:88 a owl:Class ;
+    schema:name "Speise- und Futterkartoffeln"@de,
+        "Table and fodder potatoes"@en,
+        "pommes de terre de consommation et fourragère"@fr,
+        "Patate da tavola e da foraggio"@it ;
+    rdfs:subClassOf cultivationtype:410 .
+
 cultivationtype:89 a owl:Class ;
     schema:name "Speisezwiebel"@de,
         "oignon (condiment)"@fr,
@@ -572,6 +586,13 @@ cultivationtype:92 a owl:Class ;
         "scorsonère"@fr,
         "Scorzonera"@it ;
     rdfs:subClassOf cultivationtype:95 .
+
+cultivationtype:93 a owl:Class ;
+    schema:name "Sanddorn"@de,
+        "Sea buckthorn"@en,
+        "Argousier"@fr,
+        "Olivello spinoso"@it ;
+    rdfs:subClassOf cultivationtype:1158 .
 
 cultivationtype:94 a owl:Class ;
     schema:name "Sellerie"@de,
@@ -1078,6 +1099,13 @@ cultivationtype:205 a owl:Class ;
         "Camomilla romana"@it ;
     rdfs:subClassOf cultivationtype:67 .
 
+cultivationtype:206 a owl:Class ;
+    schema:name "Spitzwegerich"@de,
+        "Ribwort plantain"@en,
+        "plantain lancéolé"@fr,
+        "piantaggine lanciuola"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
 cultivationtype:207 a owl:Class ;
     schema:name "Einlegegurken"@de,
         "cornichons"@fr,
@@ -1337,6 +1365,13 @@ cultivationtype:261 a owl:Class ;
         "Rodiola"@it ;
     rdfs:subClassOf cultivationtype:706 .
 
+cultivationtype:262 a owl:Class ;
+    schema:name "Traubensilberkerze"@de,
+        "Black cohosh"@en,
+        "Actée à grappes"@fr,
+        "Cimicifuga"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
 cultivationtype:263 a owl:Class ;
     schema:name "Lippenblütler"@de,
         "lamiacées"@fr,
@@ -1424,6 +1459,13 @@ cultivationtype:278 a owl:Class ;
         "roquette"@fr,
         "Rucola"@it ;
     rdfs:subClassOf cultivationtype:48 .
+
+cultivationtype:279 a owl:Class ;
+    schema:name "Wolliger Fingerhut"@de,
+        "Grecian foxglove"@en,
+        "digitale lanifère"@fr,
+        "Digitale lanata"@it ;
+    rdfs:subClassOf cultivationtype:706 .
 
 cultivationtype:282 a owl:Class ;
     schema:name "Stielmus"@de,
@@ -1754,6 +1796,13 @@ cultivationtype:411 a owl:Class ;
         "pommes de terre pour la production de plants"@fr,
         "Patate per la produzione di tuberi-seme"@it ;
     rdfs:subClassOf cultivationtype:410 .
+
+cultivationtype:412 a owl:Class ;
+    schema:name "Süssdolde"@de,
+        "Sweet cicely"@en,
+        "Cerfeuil musqué"@fr,
+        "Finocchiella"@it ;
+    rdfs:subClassOf cultivationtype:706 .
 
 cultivationtype:468 a owl:Class ;
     schema:name "Ackerbohne"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -2298,19 +2298,19 @@ cultivationtype:556 a owl:Class ;
     schema:name "Buntbrache"@de,
         "Jachère florale"@fr,
         "Maggese fioriti"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:77 .
 
 cultivationtype:557 a owl:Class ;
     schema:name "Rotationsbrache"@de,
         "Jachère tournante"@fr,
         "Maggese da rotazione"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:77 .
 
 cultivationtype:558 a owl:DeprecatedClass ;
-    schema:name "Grünbrache (nur 1999)"@de,
-        "Jachères vertes (uniquement en 1999)"@fr,
-        "Maggesi verdi (1999)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    schema:name "Grünbrache"@de,
+        "Jachères vertes"@fr,
+        "Maggesi verdi"@it ;
+    rdfs:subClassOf cultivationtype:77 .
 
 cultivationtype:559 a owl:Class ;
     schema:name "Saum auf Ackerflächen"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -507,6 +507,12 @@ cultivationtype:76 a owl:Class ;
         "bietola a coste"@it ;
     rdfs:subClassOf cultivationtype:321 .
 
+cultivationtype:77 a owl:Class ;
+    schema:name "Brache"@de,
+        "jachère"@fr,
+        "Maggese"@it ;
+    rdfs:subClassOf cultivationtype:1 .
+
 cultivationtype:79 a owl:Class ;
     schema:name "Grasbestände zur Saatgutproduktion"@de,
         "Graminées pour la production de semences"@fr,
@@ -1649,6 +1655,12 @@ cultivationtype:321 a owl:Class ;
         "bette"@fr,
         "Bietola"@it ;
     rdfs:subClassOf cultivationtype:300 .
+
+cultivationtype:322 a owl:Class ;
+    schema:name "Brachland"@de,
+        "friche"@fr,
+        "Terreno incolto"@it ;
+    rdfs:subClassOf :Cultivation .
 
 cultivationtype:323 a owl:Class ;
     schema:name "Lauch"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -144,6 +144,7 @@ cultivationtype:4 a owl:Class ;
         "Vignobles"@fr,
         "Vigna"@it,
         "Vines"@en ;
+    schema:alternateName "Weinbau"@de ;
     rdfs:subClassOf :Cultivation ;
     owl:unionOf ( cultivationtype:701 cultivationtype:735 ) .
 
@@ -366,6 +367,12 @@ cultivationtype:41 a owl:Class ;
         "Pero / Nashi"@it ;
     rdfs:subClassOf cultivationtype:309 .
 
+cultivationtype:43 a owl:Class ;
+    schema:name "Jostabeere"@de,
+        "josta"@fr,
+        "Josta"@it ;
+    rdfs:subClassOf cultivationtype:131 .
+
 cultivationtype:45 a owl:Class ;
     schema:name "Fichte"@de,
         "épicéa"@fr,
@@ -512,6 +519,12 @@ cultivationtype:81 a owl:Class ;
         "Cavoli a testa"@it ;
     rdfs:subClassOf cultivationtype:25 .
 
+cultivationtype:83 a owl:Class ;
+    schema:name "Medizinalkräuter"@de,
+        "plantes médicinales"@fr,
+        "erbe medicinali"@it ;
+    rdfs:subClassOf cultivationtype:35 .
+
 cultivationtype:84 a owl:Class ;
     schema:name "Bodenkohlrabi"@de,
         "rutabaga"@fr,
@@ -547,6 +560,12 @@ cultivationtype:90 a owl:Class ;
         "tomate à grappe"@fr,
         "Pomodoro ramato"@it ;
     rdfs:subClassOf cultivationtype:85 .
+
+cultivationtype:91 a owl:Class ;
+    schema:name "Gemeine Felsenbirne"@de,
+        "amélavier commun"@fr,
+        "Pero corvino"@it ;
+    rdfs:subClassOf cultivationtype:402 .
 
 cultivationtype:92 a owl:Class ;
     schema:name "Schwarzwurzel"@de,
@@ -591,6 +610,12 @@ cultivationtype:103 a owl:Class ;
         "laitues à tondre (Asteraceae)"@fr,
         "Insalate a foglie (Asteracee)"@it ;
     rdfs:subClassOf cultivationtype:105 .
+
+cultivationtype:104 a owl:Class ;
+    schema:name "Mohn"@de,
+        "pavot"@fr,
+        "Papavero"@it ;
+    rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:105 a owl:Class ;
     schema:name "Lactuca-Salate"@de,
@@ -771,6 +796,14 @@ cultivationtype:139 a owl:Class ;
         "Insalate asiatiche (Brassicacee)"@it ;
     rdfs:subClassOf cultivationtype:48 .
 
+cultivationtype:140 a owl:Class ;
+    schema:name "Blaue Heckenkirsche"@de,
+        "camérisier bleu"@fr,
+        "Caprifoglio turchino"@it ;
+    schema:alternateName "Maibeere"@de,
+        "Haskap-Beere"@de ;
+    :cultivationType cultivationtype:1158 .
+
 cultivationtype:141 a owl:Class ;
     schema:name "Endivien und Blattzichorien"@de,
         "chicorée pommée et chicorée à feuilles"@fr,
@@ -871,6 +904,12 @@ cultivationtype:161 a owl:Class ;
         "Sambuco nero"@it ;
     rdfs:subClassOf cultivationtype:471 .
 
+cultivationtype:162 a owl:Class ;
+    schema:name "Forstliche Pflanzgärten"@de,
+        "pépinières forestières"@fr,
+        "Vivai forestali"@it ;
+    rdfs:subClassOf cultivationtype:901 .
+
 cultivationtype:165 a owl:Class ;
     schema:name "Puffbohne"@de,
         "fève"@fr,
@@ -908,11 +947,25 @@ cultivationtype:171 a owl:Class ;
         "Fagioli senza baccello"@it ;
     rdfs:subClassOf cultivationtype:3 .
 
+cultivationtype:172 a owl:Class ;
+    schema:name "Lorbeer"@de,
+        "Bay leaf"@en,
+        "Laurier"@fr,
+        "Alloro"@it ;
+    rdfs:subClassOf cultivationtype:67 .
+
 cultivationtype:173 a owl:Class ;
     schema:name "Kopfsalate"@de,
         "laitues pommées"@fr,
         "Insalate cappuccio"@it ;
     rdfs:subClassOf cultivationtype:105 .
+
+cultivationtype:174 a owl:Class ;
+    schema:name "Eberesche"@de,
+        "sorbier des oiseleurs"@fr,
+        "Sorbo degli ucellatori"@it ;
+    schema:alternateName "Vogelbeere"@de ;
+    rdfs:subClassOf cultivationtype:402 .
 
 cultivationtype:175 a owl:Class ;
     schema:name "Nachtschattengewächse (Solanaceae)"@de,
@@ -1277,6 +1330,13 @@ cultivationtype:260 a owl:Class ;
     schema:alternateName "Feldsalat"@de ;
     rdfs:subClassOf cultivationtype:209 .
 
+cultivationtype:261 a owl:Class ;
+    schema:name "Rosenwurz"@de,
+        "Roseroot"@en,
+        "Orpin rose"@fr,
+        "Rodiola"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
 cultivationtype:263 a owl:Class ;
     schema:name "Lippenblütler"@de,
         "lamiacées"@fr,
@@ -1295,6 +1355,13 @@ cultivationtype:265 a owl:Class ;
         "laitue pommée"@fr,
         "Lattuga cappuccio"@it ;
     rdfs:subClassOf cultivationtype:173 .
+
+cultivationtype:267 a owl:Class ;
+    schema:name "Gojibeere"@de,
+        "Goji berry, wolfberry"@en,
+        "Baies de Goji"@fr,
+        "Bacche di Goji"@it ;
+    rdfs:subClassOf cultivationtype:1158 .
 
 cultivationtype:268 a owl:Class ;
     schema:name "Thymian"@de,
@@ -1370,6 +1437,12 @@ cultivationtype:283 a owl:Class ;
         "Ciliegio"@it ;
     rdfs:subClassOf cultivationtype:704 .
 
+cultivationtype:287 a owl:Class ;
+    schema:name "Melisse"@de,
+        "mélisse"@fr,
+        "Melissa"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
 cultivationtype:288 a owl:Class ;
     schema:name "Himbeere"@de,
         "framboise"@fr,
@@ -1387,6 +1460,13 @@ cultivationtype:290 a owl:Class ;
         "choux"@fr,
         "Cavoli"@it ;
     rdfs:subClassOf cultivationtype:22 .
+
+cultivationtype:294 a owl:Class ;
+    schema:name "Kerbelrübe"@de,
+        "Cerfeuil tubéreux"@fr,
+        "Cerfoglio bulboso"@it ;
+    schema:alternateName "Knollenkerbel"@de ;
+    rdfs:subClassOf cultivationtype:327 .
 
 cultivationtype:295 a owl:Class ;
     schema:name "Majoran"@de,
@@ -1453,6 +1533,13 @@ cultivationtype:306 a owl:Class ;
     schema:alternateName "Petersilienwurzel"@de ;
     rdfs:subClassOf cultivationtype:327 .
 
+cultivationtype:307 a owl:Class ;
+    schema:name "Kichererbse"@de,
+        "chickpea"@en,
+        "pois chiche"@fr,
+        "cece"@it ;
+    rdfs:subClassOf cultivationtype:15 .
+
 cultivationtype:308 a owl:Class ;
     schema:name "Rosmarin"@de,
         "Rosemary"@en,
@@ -1482,7 +1569,7 @@ cultivationtype:312 a owl:Class ;
     schema:name "Blumenknollen"@de,
         "tubercules de fleurs"@fr,
         "Radici tuberose floreali"@it ;
-    rdfs:subClassOf cultivationtype:329 .
+    rdfs:subClassOf cultivationtype:409 .
 
 cultivationtype:314 a owl:Class ;
     schema:name "Patisson"@de,
@@ -1502,6 +1589,12 @@ cultivationtype:317 a owl:Class ;
         "portulacacées (Portulacaceae)"@fr,
         "Portulacee (Portulacaceae)"@it ;
     rdfs:subClassOf cultivationtype:22 .
+
+cultivationtype:318 a owl:Class ;
+    schema:name "Ranunkel"@de,
+        "ranunculus"@fr,
+        "ranuncolo"@it ;
+    rdfs:subClassOf cultivationtype:145 .
 
 cultivationtype:320 a owl:Class ;
     schema:name "Salate (Asteraceae)"@de,
@@ -1557,6 +1650,12 @@ cultivationtype:329 a owl:Class ;
         "culture ornementale"@fr,
         "Coltivazione piante ornam."@it ;
     rdfs:subClassOf :Cultivation .
+
+cultivationtype:330 a owl:Class ;
+    schema:name "Gewürzfenchel"@de,
+        "fenouil aromatique"@fr,
+        "Finocchio aromatico"@it ;
+    rdfs:subClassOf cultivationtype:67 .
 
 cultivationtype:331 a owl:Class ;
     schema:name "Romanesco"@de,
@@ -1627,7 +1726,7 @@ cultivationtype:407 a owl:Class ;
     schema:name "Blumenzwiebeln"@de,
         "bulbes des fleurs"@fr,
         "Bulbi di fiori"@it ;
-    rdfs:subClassOf cultivationtype:329 .
+    rdfs:subClassOf cultivationtype:409 .
 
 cultivationtype:408 a owl:Class ;
     schema:name "Anemone"@de,
@@ -1636,6 +1735,25 @@ cultivationtype:408 a owl:Class ;
     rdfs:subClassOf cultivationtype:145,
         cultivationtype:310,
         cultivationtype:312 .
+
+cultivationtype:409 a owl:Class ;
+    schema:name "Blumenzwiebeln und Blumenknollen"@de,
+        "bulbes ornementaux"@fr,
+        "Bulbi ornamentali"@it ;
+    rdfs:subClassOf cultivationtype:329 .
+
+cultivationtype:410 a owl:Class ;
+    schema:name "Kartoffeln"@de,
+        "Pommes de terre"@fr,
+        "Patate"@it ;
+    rdfs:subClassOf cultivationtype:17 ;
+    owl:unionOf ( cultivationtype:524 cultivationtype:525 ) .
+
+cultivationtype:411 a owl:Class ;
+    schema:name "Kartoffeln zur Pflanzgutproduktion"@de,
+        "pommes de terre pour la production de plants"@fr,
+        "Patate per la produzione di tuberi-seme"@it ;
+    rdfs:subClassOf cultivationtype:410 .
 
 cultivationtype:468 a owl:Class ;
     schema:name "Ackerbohne"@de,
@@ -1926,16 +2044,13 @@ cultivationtype:523 a owl:Class ;
     rdfs:subClassOf cultivationtype:17 .
 
 cultivationtype:524 a owl:Class ;
-    schema:name "Kartoffeln"@de,
-        "Pommes de terre"@fr,
-        "Patate"@it ;
-    rdfs:subClassOf cultivationtype:17 .
+    schema:name "Kartoffeln (ohne Vertragsanbau)"@de ;
+    owl:disjointWith cultivationtype:525 .
 
 cultivationtype:525 a owl:Class ;
     schema:name "Pflanzkartoffeln (Vertragsanbau)"@de,
         "Plants de pommes de terre (contrat de culture)"@fr,
-        "Tuberi-seme di patate (coltivazione contrattuale)"@it ;
-    rdfs:subClassOf cultivationtype:524 .
+        "Tuberi-seme di patate (coltivazione contrattuale)"@it .
 
 cultivationtype:526 a owl:Class ;
     schema:name "Sommerraps zur Speiseölgewinnung"@de,
@@ -2808,6 +2923,7 @@ cultivationtype:901 a owl:Class ;
     schema:name "Wald"@de,
         "Forêt"@fr,
         "Bosco"@it ;
+    schema:alternateName "Allg. Forstwirtschaft"@de ;
     rdfs:subClassOf :Cultivation .
 
 cultivationtype:902 a owl:Class ;

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -21,7 +21,8 @@ cultivationtype:1 a owl:Class ;
         "Superficie coltiva"@it ;
     schema:alternateName "Ackerkulturen"@de,
         "Allg. Feldbau"@de,
-        "Domaine app. grande culture"@fr ;
+        "Domaine app. grande culture"@fr,
+        "Grande culture en général"@fr ;
     rdfs:comment "Umfasst Flächen, die im Rahmen der Fruchtfolge für den Anbau von einjährigen oder temporären Kulturen genutzt werden."@de ;
     rdfs:subClassOf :Cultivation .
 
@@ -242,6 +243,12 @@ cultivationtype:1039 a owl:Class ;
         "Colza de printemps"@fr,
         "Colza primaverile"@it ;
     rdfs:subClassOf cultivationtype:494 .
+
+cultivationtype:104 a owl:Class ;
+    rdfs:label "Mohn"@de,
+        "pavot"@fr,
+        "Papavero"@it ;
+    rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:1040 a owl:Class ;
     rdfs:label "Kiwi"@de,
@@ -607,11 +614,107 @@ cultivationtype:1093 a owl:Class ;
         "Zucca"@it ;
     rdfs:subClassOf cultivationtype:235 .
 
+cultivationtype:1094 a owl:Class ;
+    rdfs:label "Portulak (geschützter Anbau)"@de,
+        "Pourpier (culture protégée)"@fr,
+        "Portulaca (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:75 cultivationtype:7 ) .
+
+cultivationtype:1095 a owl:Class ;
+    rdfs:label "Süsslupinen"@de,
+        "Lupins doux"@fr,
+        "Lupini dolci"@it ;
+    rdfs:subClassOf cultivationtype:538 .
+
+cultivationtype:1096 a owl:Class ;
+    rdfs:label "Radicchio und Cicorino für Verarbeitung"@de,
+        "Radicchio et cicorino d'industrie"@fr,
+        "Radicchio e cicorino da industria"@it ;
+    rdfs:subClassOf cultivationtype:133 .
+
+cultivationtype:1097 a owl:Class ;
+    rdfs:label "Himbeer-Jungpflanzen (Long-Cane)"@de,
+        "Jeunes plants de framboisiers (Long-Cane)"@fr,
+        "Giovani piante di lampone (Long-Cane)"@it ;
+    rdfs:subClassOf cultivationtype:723 .
+
+cultivationtype:1098 a owl:Class ;
+    rdfs:label "Blaue Malve"@de,
+        "Grande mauve"@fr,
+        "Malva selvatica"@it ;
+    rdfs:subClassOf cultivationtype:35 .
+
+cultivationtype:1099 a owl:Class ;
+    rdfs:label "Rucola, 1 Schnitt (geschützter Anbau)"@de,
+        "Roquette (culture protégée)"@fr,
+        "Rucola (coltura protetta)"@it ;
+    rdfs:subClassOf cultivationtype:1113 .
+
 cultivationtype:110 a owl:Class ;
     rdfs:label "Artischocken"@de,
         "artichaut"@fr,
         "Carciofi"@it ;
     rdfs:subClassOf cultivationtype:95 .
+
+cultivationtype:1100 a owl:Class ;
+    rdfs:label "Rucola, 2 Schnitte (geschützter Anbau)"@de,
+        "Roquette, 2 coupes (culture protégée)"@fr,
+        "Rucola, 2 tagli (coltura protetta)"@it ;
+    rdfs:subClassOf cultivationtype:1113 .
+
+cultivationtype:1101 a owl:Class ;
+    rdfs:label "Nicht aufgeführte Ackerkulturen, Leguminosen"@de,
+        "Autres grandes cultures, légumineuses"@fr,
+        "Altre colture campicole, leguminose"@it ;
+    rdfs:subClassOf cultivationtype:15 .
+
+cultivationtype:1102 a owl:Class ;
+    rdfs:label "Edelraute"@de,
+        "Génépi"@fr,
+        "Genepì"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
+cultivationtype:1103 a owl:Class ;
+    rdfs:label "Salate, diverse, hoher Ertrag"@de,
+        "Salades, diverses, rendement élevé"@fr,
+        "Insalate, diverse, resa elevata"@it ;
+    rdfs:subClassOf cultivationtype:320 .
+
+cultivationtype:1104 a owl:Class ;
+    rdfs:label "Salate, diverse, mittlerer Ertrag"@de,
+        "Salades, diverses, rendement moyen"@fr,
+        "Insalate, diverse, resa media"@it ;
+    rdfs:subClassOf cultivationtype:320 .
+
+cultivationtype:1105 a owl:Class ;
+    rdfs:label "Wirz leicht"@de,
+        "Chou de Milan léger"@fr,
+        "Cavolo verza leggero"@it ;
+    rdfs:subClassOf cultivationtype:81 .
+
+cultivationtype:1106 a owl:Class ;
+    rdfs:label "Wirz schwer"@de,
+        "Chou de Milan lourd"@fr,
+        "Cavolo verza pesante"@it ;
+    rdfs:subClassOf cultivationtype:81 .
+
+cultivationtype:1107 a owl:Class ;
+    rdfs:label "Streue-, Torfland"@de,
+        "Surface à litière, tourbière"@fr,
+        "Terreno da strame, torbiera"@it ;
+    rdfs:subClassOf cultivationtype:8 .
+
+cultivationtype:1108 a owl:Class ;
+    rdfs:label "Kleine Freilandpflanzungen mit versch. Gemüsen"@de,
+        "Petites plantations de légumes divers en pleine terre"@fr,
+        "Piccole piantagioni di ortaggi diversi in pieno campo"@it ;
+    rdfs:subClassOf cultivationtype:24 .
+
+cultivationtype:1109 a owl:Class ;
+    rdfs:label "Kleine Gewächshauspflanzungen mit versch. Gemüsen"@de,
+        "Petites plantations en serre de légumes divers"@fr,
+        "Piccole piantagioni in serra di ortaggi diversi"@it ;
+    rdfs:subClassOf cultivationtype:23 .
 
 cultivationtype:111 a owl:Class ;
     rdfs:label "Blumenkohl"@de,
@@ -619,11 +722,131 @@ cultivationtype:111 a owl:Class ;
         "Cavolfiore"@it ;
     rdfs:subClassOf cultivationtype:324 .
 
+cultivationtype:1110 a owl:Class ;
+    rdfs:label "Bundzwiebeln, Frühjahr"@de,
+        "Oignons en botte, printemps"@fr,
+        "Cipollotti a mazzi, primavera"@it ;
+    rdfs:subClassOf cultivationtype:232 .
+
+cultivationtype:1111 a owl:Class ;
+    rdfs:label "Winterraps in 62a Nitrat-Projekt"@de,
+        "Colza d'automne en projet nitrate 62a"@fr,
+        "Colza autunnale in progetto nitrati 62a"@it ;
+    rdfs:subClassOf cultivationtype:1129 .
+
+cultivationtype:1112 a owl:Class ;
+    rdfs:label "Tabak Burley"@de,
+        "Tabac Burley"@fr,
+        "Tabacco Burley"@it ;
+    rdfs:subClassOf cultivationtype:541 .
+
+cultivationtype:1113 a owl:Class ;
+    rdfs:label "Rucola (geschützter Anbau)"@de,
+        "Roquette (culture protégée)"@fr,
+        "Rucola (coltura protetta)"@it ;
+    rdfs:subClassOf cultivationtype:278 .
+
+cultivationtype:1114 a owl:Class ;
+    rdfs:label "Spinat, 1 Schnitt, nach Mitte April gesät"@de,
+        "Épinard, 1 coupe, semé après la mi-avril"@fr,
+        "Spinaci, 1 taglio, seminato dopo la metà di aprile"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
+cultivationtype:1115 a owl:Class ;
+    rdfs:label "Spinat, 2 Schnitte, nach Mitte April gesät"@de,
+        "Épinard, 2 coupes, semé après la mi-avril"@fr,
+        "Spinaci, 2 tagli, seminato dopo la metà di aprile"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
+cultivationtype:1116 a owl:Class ;
+    rdfs:label "Spinat, 2 Schnitte, vor Mitte April gesät"@de,
+        "Épinard, 2 coupes, semé avant la mi-avril"@fr,
+        "Spinaci, 2 tagli, seminato prima della metà di aprile"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
+cultivationtype:1117 a owl:Class ;
+    rdfs:label "Spinat, Industrie, 1 Schnitt, vor Mitte April gesät"@de,
+        "Épinard d'industrie, 1 coupe, semé avant la mi-avril"@fr,
+        "Spinaci da industria, 1 taglio, seminato prima della metà di aprile"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
+cultivationtype:1118 a owl:Class ;
+    rdfs:label "Bundzwiebeln, Sommer"@de,
+        "Oignons en botte, été"@fr,
+        "Cipollotti a mazzi, estate"@it ;
+    rdfs:subClassOf cultivationtype:232 .
+
+cultivationtype:1119 a owl:Class ;
+    rdfs:label "Spinat, Industrie, 1 Schnitt, nach Mitte April gesät"@de,
+        "Épinard d'industrie, 1 coupe, semé après la mi-avril"@fr,
+        "Spinaci da industria, 1 taglio, seminato dopo la metà di aprile"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
 cultivationtype:112 a owl:Class ;
     rdfs:label "Cherrytomaten"@de,
         "tomate-cerise"@fr,
         "Pomodoro ciliegia"@it ;
     rdfs:subClassOf cultivationtype:85 .
+
+cultivationtype:1120 a owl:Class ;
+    rdfs:label "Spinat, Industrie, 2 Schnitte, vor Mitte April gesät"@de,
+        "Épinard d'industrie, 2 coupes, semé avant la mi-avril"@fr,
+        "Spinaci da industria, 2 tagli, seminato prima della metà di aprile"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
+cultivationtype:1121 a owl:Class ;
+    rdfs:label "Spinat, Industrie, 2 Schnitte, nach Mitte April gesät"@de,
+        "Épinard d'industrie, 2 coupes, semé après la mi-avril"@fr,
+        "Spinaci da industria, 2 tagli, seminato dopo la metà di aprile"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
+cultivationtype:1122 a owl:Class ;
+    rdfs:label "Spinat, 1 Schnitt, vor Mitte April gesät"@de,
+        "Épinard, 1 coupe, semé avant la mi-avril"@fr,
+        "Spinaci, 1 taglio, seminato prima della metà di aprile"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
+cultivationtype:1123 a owl:Class ;
+    rdfs:label "Spinat (geschützter Anbau)"@de,
+        "Épinard (culture protégée)"@fr,
+        "Spinaci (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:250 cultivationtype:7 ) .
+
+cultivationtype:1124 a owl:Class ;
+    rdfs:label "Frühjahrsschnitt vor Wiesenumbruch"@de,
+        "Coupe de printemps avant retournement de la prairie"@fr,
+        "Taglio primaverile prima della lavorazione del prato"@it ;
+    rdfs:subClassOf cultivationtype:601 .
+
+cultivationtype:1125 a owl:Class ;
+    rdfs:label "Kabis Lager"@de,
+        "Chou pommé de garde"@fr,
+        "Cavolo a testa da conservazione"@it ;
+    rdfs:subClassOf cultivationtype:81 .
+
+cultivationtype:1126 a owl:Class ;
+    rdfs:label "Wenig intensiv genutzte Weiden"@de,
+        "Pâturages peu intensifs"@fr,
+        "Pascoli poco intensivi"@it ;
+    rdfs:subClassOf cultivationtype:616 .
+
+cultivationtype:1127 a owl:Class ;
+    rdfs:label "Bundzwiebeln, Überwinterung"@de,
+        "Oignons en botte, hivernage"@fr,
+        "Cipollotti a mazzi, svernamento"@it ;
+    rdfs:subClassOf cultivationtype:232 .
+
+cultivationtype:1128 a owl:Class ;
+    rdfs:label "Erdbeeren mehrjährig"@de,
+        "Fraises pluriannuelles"@fr,
+        "Fragole pluriennali"@it ;
+    rdfs:subClassOf cultivationtype:223 .
+
+cultivationtype:1129 a owl:Class ;
+    rdfs:label "Winterraps"@de,
+        "Colza d'automne"@fr,
+        "Colza autunnale"@it ;
+    rdfs:subClassOf cultivationtype:494 .
 
 cultivationtype:113 a owl:Class ;
     rdfs:label "Zwetschgen und Pflaumen"@de,
@@ -632,11 +855,263 @@ cultivationtype:113 a owl:Class ;
     rdfs:subClassOf cultivationtype:704 ;
     owl:unionOf ( cultivationtype:259 cultivationtype:198 ) .
 
+cultivationtype:1130 a owl:Class ;
+    rdfs:label "Erdbeeren-Jungpflanzen (Tray-Pflanzen)"@de,
+        "Jeunes plants de fraisiers (plants en mottes/tray)"@fr,
+        "Giovani piante di fragola (piante in alveolo/tray)"@it ;
+    rdfs:subClassOf cultivationtype:223 .
+
+cultivationtype:1131 a owl:Class ;
+    rdfs:label "Zuckerhut (Convenience)"@de,
+        "Chicorée pain de sucre (convenience)"@fr,
+        "Cicoria pan di zucchero (convenience)"@it ;
+    rdfs:subClassOf cultivationtype:142 .
+
+cultivationtype:1132 a owl:Class ;
+    rdfs:label "Heuwiesen Sömmerungsg., extensive"@de,
+        "Prairies de fauche de la région d'estivage, extensives"@fr,
+        "Prati da sfalcio nella regione d'estivazione, estensivi"@it ;
+    rdfs:subClassOf cultivationtype:480 .
+
+cultivationtype:1133 a owl:Class ;
+    rdfs:label "Heuwiesen Sömmerungsg., wenig intensiv"@de,
+        "Prairies de fauche de la région d'estivage, peu intensives"@fr,
+        "Prati da sfalcio nella regione d'estivazione, poco intensivi"@it ;
+    rdfs:subClassOf cultivationtype:480 .
+
+cultivationtype:1134 a owl:Class ;
+    rdfs:label "Heuwiesen im Sömmerungsg., übrige"@de,
+        "Prairies de fauche de la région d'estivage, autres"@fr,
+        "Prati da sfalcio nella regione d'estivazione, altri"@it ;
+    rdfs:subClassOf cultivationtype:480 .
+
+cultivationtype:1135 a owl:Class ;
+    rdfs:label "Krautstiel (geschützter Anbau)"@de,
+        "Bette à côte (culture protégée)"@fr,
+        "Costa (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:76 cultivationtype:7 ) .
+
+cultivationtype:1136 a owl:Class ;
+    rdfs:label "Tabak Virginie"@de,
+        "Tabac de Virginie"@fr,
+        "Tabacco Virginia"@it ;
+    rdfs:subClassOf cultivationtype:541 .
+
+cultivationtype:1137 a owl:Class ;
+    rdfs:label "Süsskartoffeln"@de,
+        "Patates douces"@fr,
+        "Patate dolci"@it ;
+    rdfs:subClassOf cultivationtype:24 .
+
+cultivationtype:1138 a owl:Class ;
+    rdfs:label "Tafeltrauben, hoher Ertrag"@de,
+        "Raisins de table, rendement élevé"@fr,
+        "Uva da tavola, resa elevata"@it ;
+    rdfs:subClassOf cultivationtype:4 .
+
+cultivationtype:1139 a owl:Class ;
+    rdfs:label "Brennnessel"@de,
+        "Ortie"@fr,
+        "Ortica"@it ;
+    schema:alternateName "Brennessel"@de ;
+    rdfs:subClassOf cultivationtype:35 .
+
+cultivationtype:1140 a owl:Class ;
+    rdfs:label "Tafeltrauben (ohne Ertragsspezifizierung)"@de,
+        "Raisins de table (sans spécification de rendement)"@fr,
+        "Uva da tavola (senza specifica di resa)"@it ;
+    rdfs:subClassOf cultivationtype:4 .
+
+cultivationtype:1141 a owl:Class ;
+    rdfs:label "Tomaten, Bodenkultur (geschützter Anbau)"@de,
+        "Tomates, culture au sol (culture protégée)"@fr,
+        "Pomodori, coltura su suolo (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:811 cultivationtype:85 ) .
+
+cultivationtype:1142 a owl:Class ;
+    rdfs:label "Tomaten, Bodenkultur, hoher Ertrag (geschützter Anbau)"@de,
+        "Tomates, culture au sol, rendement élevé (culture protégée)"@fr,
+        "Pomodori, coltura su suolo, resa elevata (coltura protetta)"@it ;
+    rdfs:subClassOf cultivationtype:1141 .
+
+cultivationtype:1143 a owl:Class ;
+    rdfs:label "Tomaten, Bodenkulturen, tiefer Ertrag (geschützter Anbau)"@de,
+        "Tomates, culture au sol, faible rendement (culture protégée)"@fr,
+        "Pomodori, colture su suolo, resa bassa (coltura protetta)"@it ;
+    rdfs:subClassOf cultivationtype:1141 .
+
+cultivationtype:1144 a owl:Class ;
+    rdfs:label "Tomaten, Bodenkulturen, mittlerer Ertrag (geschützter Anbau)"@de,
+        "Tomates, culture au sol, rendement moyen (culture protégée)"@fr,
+        "Pomodori, colture su suolo, resa media (coltura protetta)"@it ;
+    rdfs:subClassOf cultivationtype:1141 .
+
+cultivationtype:1145 a owl:Class ;
+    rdfs:label "Tomaten, Bodenkultur, sehr hoher Ertrag (geschützter Anbau)"@de,
+        "Tomates, culture au sol, rendement très élevé (culture protégée)"@fr,
+        "Pomodori, coltura su suolo, resa molto elevata (coltura protetta)"@it ;
+    rdfs:subClassOf cultivationtype:1141 .
+
+cultivationtype:1146 a owl:Class ;
+    rdfs:label "Äugstlen"@de,
+        "Äugstlen (utilisation automnale)"@fr,
+        "Äugstlen (utilizzazione autunnale)"@it ;
+    rdfs:comment "Äugstlen: Entspricht der Herbstnutzung von Kunstwiesen, welche nach einer Hauptkultur angesät wurden."@de,
+        "Äugstlen : Correspond à l'utilisation automnale des prairies artificielles semées après une culture principale."@fr,
+        "Äugstlen: Corrisponde all'utilizzazione autunnale dei prati artificiali seminati dopo una coltura principale."@it ;
+    rdfs:subClassOf cultivationtype:601 .
+
+cultivationtype:1147 a owl:Class ;
+    rdfs:label "Herbst- und Mairüben"@de,
+        "Navets d'automne et de mai"@fr,
+        "Rape autunnali e primaverili"@it ;
+    schema:alternateName "Rüben Herbst-, Mai-"@de ;
+    rdfs:subClassOf cultivationtype:56 .
+
+cultivationtype:1148 a owl:Class ;
+    rdfs:label "Cima di Rapa"@de,
+        "Cima di rapa"@fr,
+        "Cima di rapa"@it ;
+    rdfs:subClassOf cultivationtype:48 .
+
+cultivationtype:1149 a owl:Class ;
+    rdfs:label "Bibernelle"@de,
+        "Pimprenelle"@fr,
+        "Pimpinella"@it ;
+    schema:alternateName "Pimpinelle"@de ;
+    rdfs:subClassOf cultivationtype:706 .
+
 cultivationtype:115 a owl:Class ;
     rdfs:label "Brassica napus-Rüben"@de,
         "rave de Brassica napus"@fr,
         "Rapa di Brassica napus"@it ;
     rdfs:subClassOf cultivationtype:247 .
+
+cultivationtype:1150 a owl:Class ;
+    rdfs:label "Ehrenpreis"@de,
+        "Véronique"@fr,
+        "Veronica"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
+cultivationtype:1151 a owl:Class ;
+    rdfs:label "Walnüsse < 185 Bäume/ha"@de,
+        "Noyers < 185 arbres/ha"@fr,
+        "Noci < 185 alberi/ha"@it ;
+    rdfs:subClassOf cultivationtype:252 .
+
+cultivationtype:1152 a owl:Class ;
+    rdfs:label "Walnüsse ≥ 185 Bäume/ha"@de,
+        "Noyers ≥ 185 arbres/ha"@fr,
+        "Noci ≥ 185 alberi/ha"@it ;
+    rdfs:subClassOf cultivationtype:252 .
+
+cultivationtype:1153 a owl:Class ;
+    rdfs:label "Naturwiese mittelintensiv"@de,
+        "Prairie naturelle moyennement intensive"@fr,
+        "Prato naturale medio-intensivo"@it ;
+    rdfs:subClassOf cultivationtype:2 .
+
+cultivationtype:1154 a owl:Class ;
+    rdfs:label "Kunstwiese mittelintensiv"@de,
+        "Prairie artificielle moyennement intensive"@fr,
+        "Prato artificiale medio-intensivo"@it ;
+    rdfs:subClassOf cultivationtype:601 .
+
+cultivationtype:1155 a owl:Class ;
+    rdfs:label "Naturwiese intensiv"@de,
+        "Prairie naturelle intensive"@fr,
+        "Prato naturale intensivo"@it ;
+    rdfs:subClassOf cultivationtype:2 .
+
+cultivationtype:1156 a owl:Class ;
+    rdfs:label "Winterspinat, 1 Schnitt"@de,
+        "Épinard d'hiver, 1 coupe"@fr,
+        "Spinaci invernali, 1 taglio"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
+cultivationtype:1157 a owl:Class ;
+    rdfs:label "Winterspinat, 2 Schnitte"@de,
+        "Épinard d'hiver, 2 coupes"@fr,
+        "Spinaci invernali, 2 tagli"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
+cultivationtype:1158 a owl:Class ;
+    rdfs:label "Alternative Strauchbeeren (Aronia, Holunder, Goji,…)"@de,
+        "Autres baies arbustives (aronia, sureau, goji,…)"@fr,
+        "Bacche arbustive alternative (aronia, sambuco, goji,…)"@it ;
+    rdfs:subClassOf cultivationtype:471 .
+
+cultivationtype:1159 a owl:Class ;
+    rdfs:label "Broccoli, Verarbeitung"@de,
+        "Brocoli d'industrie"@fr,
+        "Broccoli da industria"@it ;
+    rdfs:subClassOf cultivationtype:154 .
+
+cultivationtype:116 a owl:Class ;
+    rdfs:label "Wiesen und Weiden"@de,
+        "Prairies et pâturages"@fr,
+        "Prati e pascoli"@it ;
+    rdfs:subClassOf :Cultivation .
+
+cultivationtype:1160 a owl:Class ;
+    rdfs:label "Winterspinat, Industrie, 1 Schnitt"@de,
+        "Épinard d'hiver d'industrie, 1 coupe"@fr,
+        "Spinaci invernali da industria, 1 taglio"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
+cultivationtype:1161 a owl:Class ;
+    rdfs:label "Winterspinat, Industrie, 2 Schnitte"@de,
+        "Épinard d'hiver d'industrie, 2 coupes"@fr,
+        "Spinaci invernali da industria, 2 tagli"@it ;
+    rdfs:subClassOf cultivationtype:250 .
+
+cultivationtype:1162 a owl:Class ;
+    rdfs:label "Schafgarbe"@de,
+        "Achillée millefeuille"@fr,
+        "Achillea"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
+cultivationtype:1163 a owl:Class ;
+    rdfs:label "Zucchetti, gepflanzt, frühe Kurzkultur"@de,
+        "Courgette, plantée, culture courte précoce"@fr,
+        "Zucchine, piantate, coltura breve precoce"@it ;
+    rdfs:subClassOf cultivationtype:225 .
+
+cultivationtype:1164 a owl:Class ;
+    rdfs:label "Patisson, Kürbis (geschützter Anbau)"@de,
+        "Pâtisson, courge (culture protégée)"@fr,
+        "Patisson, zucca (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:1093 cultivationtype:7 ) .
+
+cultivationtype:1165 a owl:Class ;
+    rdfs:label "Zucchetti, gepflanzt, Sommer und Herbst"@de,
+        "Courgette, plantée, été et automne"@fr,
+        "Zucchine, piantate, estate e autunno"@it ;
+    rdfs:subClassOf cultivationtype:225 .
+
+cultivationtype:1166 a owl:Class ;
+    rdfs:label "Zucchetti (geschützter Anbau)"@de,
+        "Courgette (culture protégée)"@fr,
+        "Zucchine (coltura protetta)"@it ;
+    owl:intersectionOf ( cultivationtype:225 cultivationtype:7 ) .
+
+cultivationtype:1167 a owl:Class ;
+    rdfs:label "Patisson, Kürbis"@de,
+        "Pâtisson, courge"@fr,
+        "Patisson, zucca"@it ;
+    rdfs:subClassOf cultivationtype:1093 .
+
+cultivationtype:1168 a owl:Class ;
+    rdfs:label "Zucchetti, gesät, Sommer und Herbst"@de,
+        "Courgette, semée, été et automne"@fr,
+        "Zucchine, seminate, estate e autunno"@it ;
+    rdfs:subClassOf cultivationtype:225 .
+
+cultivationtype:1169 a owl:Class ;
+    rdfs:label "Heuwiesen im Sömmerungsg., übrige"@de,
+        "Prairies de fauche dans la région d'estivage, autres"@fr,
+        "Prati da sfalcio nella regione d'estivazione, altri"@it ;
+    rdfs:subClassOf cultivationtype:480 .
 
 cultivationtype:117 a owl:Class ;
     rdfs:label "Stachys"@de,
@@ -769,6 +1244,14 @@ cultivationtype:14 a owl:Class ;
     rdfs:comment "Der Anbau von verschiedenen Getreidearten wie Weizen, Gerste, Roggen, Hafer oder Dinkel. Das Hauptziel ist die Gewinnung der Körner zur Nutzung als Lebens- oder Futtermittel."@de ;
     rdfs:subClassOf cultivationtype:1032 .
 
+cultivationtype:140 a owl:Class ;
+    rdfs:label "Blaue Heckenkirsche"@de,
+        "camérisier bleu"@fr,
+        "Caprifoglio turchino"@it ;
+    schema:alternateName "Haskap-Beere"@de,
+        "Maibeere"@de ;
+    :cultivationType cultivationtype:1158 .
+
 cultivationtype:141 a owl:Class ;
     rdfs:label "Endivien und Blattzichorien"@de,
         "chicorée pommée et chicorée à feuilles"@fr,
@@ -881,6 +1364,12 @@ cultivationtype:161 a owl:Class ;
         "Sambuco nero"@it ;
     rdfs:subClassOf cultivationtype:471 .
 
+cultivationtype:162 a owl:Class ;
+    rdfs:label "Forstliche Pflanzgärten"@de,
+        "pépinières forestières"@fr,
+        "Vivai forestali"@it ;
+    rdfs:subClassOf cultivationtype:901 .
+
 cultivationtype:165 a owl:Class ;
     rdfs:label "Puffbohne"@de,
         "fève"@fr,
@@ -900,6 +1389,12 @@ cultivationtype:167 a owl:Class ;
     rdfs:subClassOf cultivationtype:118,
         cultivationtype:72 .
 
+cultivationtype:169 a owl:Class ;
+    rdfs:label "Chinaschilf"@de,
+        "Roseau de Chine"@fr,
+        "Miscanto"@it ;
+    rdfs:subClassOf cultivationtype:707 .
+
 cultivationtype:17 a owl:Class ;
     rdfs:label "Hackfrüchte"@de,
         "Root crops"@en ;
@@ -917,11 +1412,25 @@ cultivationtype:171 a owl:Class ;
         "Fagioli senza baccello"@it ;
     rdfs:subClassOf cultivationtype:3 .
 
+cultivationtype:172 a owl:Class ;
+    rdfs:label "Lorbeer"@de,
+        "Bay leaf"@en,
+        "Laurier"@fr,
+        "Alloro"@it ;
+    rdfs:subClassOf cultivationtype:67 .
+
 cultivationtype:173 a owl:Class ;
     rdfs:label "Kopfsalate"@de,
         "laitues pommées"@fr,
         "Insalate cappuccio"@it ;
     rdfs:subClassOf cultivationtype:105 .
+
+cultivationtype:174 a owl:Class ;
+    rdfs:label "Eberesche"@de,
+        "sorbier des oiseleurs"@fr,
+        "Sorbo degli ucellatori"@it ;
+    schema:alternateName "Vogelbeere"@de ;
+    rdfs:subClassOf cultivationtype:402 .
 
 cultivationtype:175 a owl:Class ;
     rdfs:label "Nachtschattengewächse (Solanaceae)"@de,
@@ -938,6 +1447,12 @@ cultivationtype:179 a owl:Class ;
 cultivationtype:18 a owl:Class ;
     rdfs:label "Mischkultur"@de ;
     rdfs:subClassOf cultivationtype:1 .
+
+cultivationtype:182 a owl:Class ;
+    rdfs:label "Kleegrasmischung (Kunstwiese)"@de,
+        "mélange trèfles-graminées (prairie arificielle)"@fr,
+        "Miscela trifoglio-graminacee (prati artificiali)"@it ;
+    rdfs:subClassOf cultivationtype:116 .
 
 cultivationtype:183 a owl:Class ;
     rdfs:label "Linse"@de,
@@ -975,6 +1490,12 @@ cultivationtype:19 a owl:Class ;
         "Céréales d'automne"@fr,
         "Cereali autunnali"@it ;
     rdfs:subClassOf cultivationtype:1033 .
+
+cultivationtype:190 a owl:Class ;
+    rdfs:label "Winterraps"@de,
+        "Colza d'automne"@fr,
+        "Colza autunnale"@it ;
+    rdfs:subClassOf cultivationtype:494 .
 
 cultivationtype:191 a owl:Class ;
     rdfs:label "Erbsen"@de,
@@ -1328,6 +1849,13 @@ cultivationtype:260 a owl:Class ;
     schema:alternateName "Feldsalat"@de ;
     rdfs:subClassOf cultivationtype:209 .
 
+cultivationtype:261 a owl:Class ;
+    rdfs:label "Rosenwurz"@de,
+        "Roseroot"@en,
+        "Orpin rose"@fr,
+        "Rodiola"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
 cultivationtype:263 a owl:Class ;
     rdfs:label "Lippenblütler"@de,
         "lamiacées"@fr,
@@ -1346,6 +1874,13 @@ cultivationtype:265 a owl:Class ;
         "laitue pommée"@fr,
         "Lattuga cappuccio"@it ;
     rdfs:subClassOf cultivationtype:173 .
+
+cultivationtype:267 a owl:Class ;
+    rdfs:label "Gojibeere"@de,
+        "Goji berry, wolfberry"@en,
+        "Baies de Goji"@fr,
+        "Bacche di Goji"@it ;
+    rdfs:subClassOf cultivationtype:1158 .
 
 cultivationtype:268 a owl:Class ;
     rdfs:label "Thymian"@de,
@@ -1427,6 +1962,12 @@ cultivationtype:283 a owl:Class ;
         "Ciliegio"@it ;
     rdfs:subClassOf cultivationtype:704 .
 
+cultivationtype:287 a owl:Class ;
+    rdfs:label "Melisse"@de,
+        "mélisse"@fr,
+        "Melissa"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
 cultivationtype:288 a owl:Class ;
     rdfs:label "Himbeere"@de,
         "framboise"@fr,
@@ -1444,6 +1985,13 @@ cultivationtype:290 a owl:Class ;
         "choux"@fr,
         "Cavoli"@it ;
     rdfs:subClassOf cultivationtype:22 .
+
+cultivationtype:294 a owl:Class ;
+    rdfs:label "Kerbelrübe"@de,
+        "Cerfeuil tubéreux"@fr,
+        "Cerfoglio bulboso"@it ;
+    schema:alternateName "Knollenkerbel"@de ;
+    rdfs:subClassOf cultivationtype:327 .
 
 cultivationtype:295 a owl:Class ;
     rdfs:label "Majoran"@de,
@@ -1510,6 +2058,12 @@ cultivationtype:304 a owl:Class ;
         "Varietà particolari di pomodoro"@it ;
     rdfs:subClassOf cultivationtype:85 .
 
+cultivationtype:305 a owl:Class ;
+    rdfs:label "Futter- und Zuckerrüben"@de,
+        "betteraves à sucre et fourragère"@fr,
+        "Barbabietole da foraggio e da zucchero"@it ;
+    owl:intersectionOf ( cultivationtype:522 cultivationtype:523 ) .
+
 cultivationtype:306 a owl:Class ;
     rdfs:label "Wurzelpetersilie"@de,
         "Turnip-rooted parsley"@en,
@@ -1517,6 +2071,13 @@ cultivationtype:306 a owl:Class ;
         "Prezzemolo tuberoso"@it ;
     schema:alternateName "Petersilienwurzel"@de ;
     rdfs:subClassOf cultivationtype:327 .
+
+cultivationtype:307 a owl:Class ;
+    rdfs:label "Kichererbse"@de,
+        "chickpea"@en,
+        "pois chiche"@fr,
+        "cece"@it ;
+    rdfs:subClassOf cultivationtype:15 .
 
 cultivationtype:308 a owl:Class ;
     rdfs:label "Rosmarin"@de,
@@ -1553,7 +2114,7 @@ cultivationtype:312 a owl:Class ;
     rdfs:label "Blumenknollen"@de,
         "tubercules de fleurs"@fr,
         "Radici tuberose floreali"@it ;
-    rdfs:subClassOf cultivationtype:329 .
+    rdfs:subClassOf cultivationtype:409 .
 
 cultivationtype:314 a owl:Class ;
     rdfs:label "Patisson"@de,
@@ -1573,6 +2134,12 @@ cultivationtype:317 a owl:Class ;
         "portulacacées (Portulacaceae)"@fr,
         "Portulacee (Portulacaceae)"@it ;
     rdfs:subClassOf cultivationtype:22 .
+
+cultivationtype:318 a owl:Class ;
+    rdfs:label "Ranunkel"@de,
+        "ranunculus"@fr,
+        "ranuncolo"@it ;
+    rdfs:subClassOf cultivationtype:145 .
 
 cultivationtype:32 a owl:Class ;
     rdfs:label "Gurken"@de,
@@ -1642,6 +2209,12 @@ cultivationtype:33 a owl:Class ;
         "Valeriana"@it ;
     rdfs:subClassOf cultivationtype:22 .
 
+cultivationtype:330 a owl:Class ;
+    rdfs:label "Gewürzfenchel"@de,
+        "fenouil aromatique"@fr,
+        "Finocchio aromatico"@it ;
+    rdfs:subClassOf cultivationtype:67 .
+
 cultivationtype:331 a owl:Class ;
     rdfs:label "Romanesco"@de,
         "romanesco"@fr,
@@ -1699,6 +2272,7 @@ cultivationtype:4 a owl:Class ;
         "Vines"@en,
         "Vignobles"@fr,
         "Vigna"@it ;
+    schema:alternateName "Weinbau"@de ;
     rdfs:subClassOf :Cultivation ;
     owl:unionOf ( cultivationtype:701 cultivationtype:735 ) .
 
@@ -1758,6 +2332,20 @@ cultivationtype:407 a owl:Class ;
     rdfs:label "Blumenzwiebeln"@de,
         "bulbes des fleurs"@fr,
         "Bulbi di fiori"@it ;
+    rdfs:subClassOf cultivationtype:409 .
+
+cultivationtype:408 a owl:Class ;
+    rdfs:label "Anemone"@de,
+        "anémone"@fr,
+        "Anemone"@it ;
+    rdfs:subClassOf cultivationtype:145,
+        cultivationtype:310,
+        cultivationtype:312 .
+
+cultivationtype:409 a owl:Class ;
+    rdfs:label "Blumenzwiebeln und Blumenknollen"@de,
+        "bulbes ornementaux"@fr,
+        "Bulbi ornamentali"@it ;
     rdfs:subClassOf cultivationtype:329 .
 
 cultivationtype:41 a owl:Class ;
@@ -1765,6 +2353,25 @@ cultivationtype:41 a owl:Class ;
         "poirier / nashi"@fr,
         "Pero / Nashi"@it ;
     rdfs:subClassOf cultivationtype:309 .
+
+cultivationtype:410 a owl:Class ;
+    rdfs:label "Kartoffeln"@de,
+        "Pommes de terre"@fr,
+        "Patate"@it ;
+    rdfs:subClassOf cultivationtype:17 ;
+    owl:unionOf ( cultivationtype:524 cultivationtype:525 ) .
+
+cultivationtype:411 a owl:Class ;
+    rdfs:label "Kartoffeln zur Pflanzgutproduktion"@de,
+        "pommes de terre pour la production de plants"@fr,
+        "Patate per la produzione di tuberi-seme"@it ;
+    rdfs:subClassOf cultivationtype:410 .
+
+cultivationtype:43 a owl:Class ;
+    rdfs:label "Jostabeere"@de,
+        "josta"@fr,
+        "Josta"@it ;
+    rdfs:subClassOf cultivationtype:131 .
 
 cultivationtype:45 a owl:Class ;
     rdfs:label "Fichte"@de,
@@ -1778,6 +2385,12 @@ cultivationtype:46 a owl:Class ;
         "Cardo azzurro"@it ;
     rdfs:subClassOf cultivationtype:145,
         cultivationtype:310 .
+
+cultivationtype:468 a owl:Class ;
+    rdfs:label "Ackerbohne"@de,
+        "féverole"@fr,
+        "Fava"@it ;
+    rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:469 a owl:Class ;
     rdfs:label "Freiland-Beeren"@de ;
@@ -2082,28 +2695,26 @@ cultivationtype:523 a owl:Class ;
     rdfs:subClassOf cultivationtype:17 .
 
 cultivationtype:524 a owl:Class ;
-    rdfs:label "Kartoffeln"@de,
-        "Pommes de terre"@fr,
-        "Patate"@it ;
-    rdfs:subClassOf cultivationtype:17 .
+    rdfs:label "Kartoffeln (ohne Vertragsanbau)"@de ;
+    owl:disjointWith cultivationtype:525 .
 
 cultivationtype:525 a owl:Class ;
     rdfs:label "Pflanzkartoffeln (Vertragsanbau)"@de,
         "Plants de pommes de terre (contrat de culture)"@fr,
-        "Tuberi-seme di patate (coltivazione contrattuale)"@it ;
-    rdfs:subClassOf cultivationtype:524 .
+        "Tuberi-seme di patate (coltivazione contrattuale)"@it .
 
 cultivationtype:526 a owl:Class ;
     rdfs:label "Sommerraps zur Speiseölgewinnung"@de,
         "Colza de printemps destiné à la fabrication d’huile comestible"@fr,
         "Colza primaverile per l’estrazione di olio commestibile"@it ;
-    rdfs:subClassOf cultivationtype:496 .
+    rdfs:subClassOf cultivationtype:1039,
+        cultivationtype:496 .
 
 cultivationtype:527 a owl:Class ;
     rdfs:label "Winterraps zur Speiseölgewinnung"@de,
         "Colza d’automne destiné à la fabrication d’huile comestible"@fr,
         "Colza autunnale per l’estrazione di olio commestibile"@it ;
-    rdfs:subClassOf cultivationtype:496 .
+    rdfs:subClassOf cultivationtype:1129 .
 
 cultivationtype:528 a owl:Class ;
     rdfs:label "Soja"@de,
@@ -2305,8 +2916,10 @@ cultivationtype:566 a owl:Class ;
 
 cultivationtype:567 a owl:Class ;
     rdfs:label "Saflor"@de,
+        "Safflower"@en,
         "Carthame"@fr,
         "Cartamo"@it ;
+    schema:alternateName "Färberdistel"@de ;
     rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:568 a owl:Class ;
@@ -2414,13 +3027,14 @@ cultivationtype:590 a owl:Class ;
     rdfs:label "Sommerraps als nachwachsender Rohstoff"@de,
         "Colza de printemps comme matière première renouvelable"@fr,
         "Colza primaverile quale materia prima rinnovabile"@it ;
-    rdfs:subClassOf cultivationtype:495 .
+    rdfs:subClassOf cultivationtype:1039,
+        cultivationtype:495 .
 
 cultivationtype:591 a owl:Class ;
     rdfs:label "Winterraps als nachwachsender Rohstoff"@de,
         "Colza d’automne comme matière première renouvelable"@fr,
         "Colza autunnale quale materia prima rinnovabile"@it ;
-    rdfs:subClassOf cultivationtype:495 .
+    rdfs:subClassOf cultivationtype:1129 .
 
 cultivationtype:592 a owl:Class ;
     rdfs:label "Sonnenblumen als nachwachsender Rohstoff"@de,
@@ -2591,6 +3205,15 @@ cultivationtype:67 a owl:Class ;
         "fines herbes"@fr,
         "Erbette da cucina"@it ;
     rdfs:subClassOf cultivationtype:22 .
+
+cultivationtype:68 a owl:Class ;
+    rdfs:label "Luzerne"@de,
+        "Luzerne"@fr,
+        "Erba medica"@it ;
+    schema:alternateName "Alfalfa"@de,
+        "Ewiger Klee"@de,
+        "Schneckenklee"@de ;
+    rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:69 a owl:Class ;
     rdfs:label "Mini-Kiwi"@de,
@@ -2821,6 +3444,12 @@ cultivationtype:760 a owl:Class ;
         "Colture perenni, senza contributi, aggregata"@it ;
     rdfs:subClassOf cultivationtype:6 .
 
+cultivationtype:79 a owl:Class ;
+    rdfs:label "Grasbestände zur Saatgutproduktion"@de,
+        "Graminées pour la production de semences"@fr,
+        "Graminacee per la produzione di sementi"@it ;
+    rdfs:subClassOf cultivationtype:1 .
+
 cultivationtype:797 a owl:Class ;
     rdfs:label "Übrige Flächen mit Dauerkulturen, beitragsberechtigt"@de,
         "Autres surfaces de cultures pérennes, avec contributions"@fr,
@@ -2917,6 +3546,12 @@ cultivationtype:814 a owl:Class ;
         "Cultures des baies sous abri sans fondations permanentes; sur des tables de plantation ou  des étagères"@fr,
         "Colture di bacche coltivate al coperto senza fondamenta fisse; su tavole di piantagione o rastrelliere"@it ;
     rdfs:subClassOf cultivationtype:470 .
+
+cultivationtype:83 a owl:Class ;
+    rdfs:label "Medizinalkräuter"@de,
+        "plantes médicinales"@fr,
+        "erbe medicinali"@it ;
+    rdfs:subClassOf cultivationtype:35 .
 
 cultivationtype:830 a owl:Class ;
     rdfs:label "Kulturen in ganzjährig geschütztem Anbau, beitragsberechtigt"@de,
@@ -3039,6 +3674,7 @@ cultivationtype:901 a owl:Class ;
     rdfs:label "Wald"@de,
         "Forêt"@fr,
         "Bosco"@it ;
+    schema:alternateName "Allg. Forstwirtschaft"@de ;
     rdfs:subClassOf :Cultivation .
 
 cultivationtype:902 a owl:Class ;
@@ -3094,6 +3730,12 @@ cultivationtype:909 a owl:Class ;
         "Jardins potager"@fr,
         "Giardini e orti domestici"@it ;
     rdfs:subClassOf cultivationtype:12 .
+
+cultivationtype:91 a owl:Class ;
+    rdfs:label "Gemeine Felsenbirne"@de,
+        "amélavier commun"@fr,
+        "Pero corvino"@it ;
+    rdfs:subClassOf cultivationtype:402 .
 
 cultivationtype:911 a owl:Class ;
     rdfs:label "Landwirtschaftliche Produktion in Gebäuden (z. B. Champignon, Brüsseler)"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -916,6 +916,12 @@ cultivationtype:1139 a owl:Class ;
     schema:alternateName "Brennessel"@de ;
     rdfs:subClassOf cultivationtype:35 .
 
+cultivationtype:114 a owl:Class ;
+    rdfs:label "Grünfläche"@de,
+        "surfaces herbagères"@fr,
+        "Superficie inerbita"@it ;
+    rdfs:subClassOf :Cultivation .
+
 cultivationtype:1140 a owl:Class ;
     rdfs:label "Tafeltrauben (ohne Ertragsspezifizierung)"@de,
         "Raisins de table (sans spécification de rendement)"@fr,
@@ -1595,7 +1601,7 @@ cultivationtype:21 a owl:Class ;
     rdfs:label "Dauergrünfläche"@de ;
     schema:alternateName "Dauergrünland"@de ;
     rdfs:comment "Als Dauergrünfläche gilt die mit Gräsern und Kräutern bewachsene Fläche ausserhalb der Sömmerungsflächen. Sie besteht seit mehr als sechs Jahren als Dauerwiese oder als Dauerweide (Art. 19 LBV)."@de ;
-    rdfs:subClassOf :Cultivation .
+    rdfs:subClassOf cultivationtype:114 .
 
 cultivationtype:211 a owl:Class ;
     rdfs:label "Rhabarber"@de,
@@ -3122,7 +3128,8 @@ cultivationtype:601 a owl:Class ;
     rdfs:label "Kunstwiesen (ohne Weiden)"@de,
         "Prairies artificielles (sans les pâturages)"@fr,
         "Prati artificiali (senza pascoli)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1,
+        cultivationtype:114 .
 
 cultivationtype:602 a owl:Class ;
     rdfs:label "Übrige Kunstwiese, beitragsberechtigt"@de,
@@ -3131,7 +3138,8 @@ cultivationtype:602 a owl:Class ;
     rdfs:comment "Übrige Kunstwiese, beitragsberechtigt (z.B. Schweineweide, Geflügelweide)"@de,
         "Autres prairies artificielles donnant droit aux contributions (p.ex. pâturages pour porcs et volaille)"@fr,
         "Altri prati artificiali avente diritto ai contributi (p.es. pascoli riservati ai suini e al pollame)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1,
+        cultivationtype:114 .
 
 cultivationtype:611 a owl:Class ;
     rdfs:label "Extensiv genutzte Wiesen (ohne Weiden)"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -244,12 +244,6 @@ cultivationtype:1039 a owl:Class ;
         "Colza primaverile"@it ;
     rdfs:subClassOf cultivationtype:494 .
 
-cultivationtype:104 a owl:Class ;
-    rdfs:label "Mohn"@de,
-        "pavot"@fr,
-        "Papavero"@it ;
-    rdfs:subClassOf cultivationtype:1 .
-
 cultivationtype:1040 a owl:Class ;
     rdfs:label "Kiwi"@de,
         "Kiwi"@fr,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -1250,7 +1250,7 @@ cultivationtype:140 a owl:Class ;
         "Caprifoglio turchino"@it ;
     schema:alternateName "Haskap-Beere"@de,
         "Maibeere"@de ;
-    :cultivationType cultivationtype:1158 .
+    rdfs:subClassOf cultivationtype:1158 .
 
 cultivationtype:141 a owl:Class ;
     rdfs:label "Endivien und Blattzichorien"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -2180,6 +2180,12 @@ cultivationtype:321 a owl:Class ;
         "Bietola"@it ;
     rdfs:subClassOf cultivationtype:300 .
 
+cultivationtype:322 a owl:Class ;
+    rdfs:label "Brachland"@de,
+        "friche"@fr,
+        "Terreno incolto"@it ;
+    rdfs:subClassOf :Cultivation .
+
 cultivationtype:323 a owl:Class ;
     rdfs:label "Lauch"@de,
         "poireau"@fr,
@@ -3471,6 +3477,12 @@ cultivationtype:760 a owl:Class ;
         "Surfaces de cultures pérennes, sans contributions, agrégée"@fr,
         "Colture perenni, senza contributi, aggregata"@it ;
     rdfs:subClassOf cultivationtype:6 .
+
+cultivationtype:77 a owl:Class ;
+    rdfs:label "Brache"@de,
+        "jachère"@fr,
+        "Maggese"@it ;
+    rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:79 a owl:Class ;
     rdfs:label "Grasbestände zur Saatgutproduktion"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -2922,13 +2922,13 @@ cultivationtype:556 a owl:Class ;
     rdfs:label "Buntbrache"@de,
         "Jachère florale"@fr,
         "Maggese fioriti"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:77 .
 
 cultivationtype:557 a owl:Class ;
     rdfs:label "Rotationsbrache"@de,
         "Jachère tournante"@fr,
         "Maggese da rotazione"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:77 .
 
 cultivationtype:559 a owl:Class ;
     rdfs:label "Saum auf Ackerflächen"@de,
@@ -3967,10 +3967,10 @@ cultivationtype:533 a owl:DeprecatedClass ;
     rdfs:subClassOf cultivationtype:535 .
 
 cultivationtype:558 a owl:DeprecatedClass ;
-    rdfs:label "Grünbrache (nur 1999)"@de,
-        "Jachères vertes (uniquement en 1999)"@fr,
-        "Maggesi verdi (1999)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:label "Grünbrache"@de,
+        "Jachères vertes"@fr,
+        "Maggesi verdi"@it ;
+    rdfs:subClassOf cultivationtype:77 .
 
 cultivationtype:561 a owl:DeprecatedClass ;
     rdfs:label "Rübsen für die Samenproduktion (Vertragsanbau)"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -1565,6 +1565,13 @@ cultivationtype:205 a owl:Class ;
         "Camomilla romana"@it ;
     rdfs:subClassOf cultivationtype:67 .
 
+cultivationtype:206 a owl:Class ;
+    rdfs:label "Spitzwegerich"@de,
+        "Ribwort plantain"@en,
+        "plantain lancéolé"@fr,
+        "piantaggine lanciuola"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
 cultivationtype:207 a owl:Class ;
     rdfs:label "Einlegegurken"@de,
         "cornichons"@fr,
@@ -1856,6 +1863,13 @@ cultivationtype:261 a owl:Class ;
         "Rodiola"@it ;
     rdfs:subClassOf cultivationtype:706 .
 
+cultivationtype:262 a owl:Class ;
+    rdfs:label "Traubensilberkerze"@de,
+        "Black cohosh"@en,
+        "Actée à grappes"@fr,
+        "Cimicifuga"@it ;
+    rdfs:subClassOf cultivationtype:706 .
+
 cultivationtype:263 a owl:Class ;
     rdfs:label "Lippenblütler"@de,
         "lamiacées"@fr,
@@ -1943,6 +1957,13 @@ cultivationtype:278 a owl:Class ;
         "roquette"@fr,
         "Rucola"@it ;
     rdfs:subClassOf cultivationtype:48 .
+
+cultivationtype:279 a owl:Class ;
+    rdfs:label "Wolliger Fingerhut"@de,
+        "Grecian foxglove"@en,
+        "digitale lanifère"@fr,
+        "Digitale lanata"@it ;
+    rdfs:subClassOf cultivationtype:706 .
 
 cultivationtype:28 a owl:Class ;
     rdfs:label "Schwarze Apfelbeere"@de,
@@ -2366,6 +2387,13 @@ cultivationtype:411 a owl:Class ;
         "pommes de terre pour la production de plants"@fr,
         "Patate per la produzione di tuberi-seme"@it ;
     rdfs:subClassOf cultivationtype:410 .
+
+cultivationtype:412 a owl:Class ;
+    rdfs:label "Süssdolde"@de,
+        "Sweet cicely"@en,
+        "Cerfeuil musqué"@fr,
+        "Finocchiella"@it ;
+    rdfs:subClassOf cultivationtype:706 .
 
 cultivationtype:43 a owl:Class ;
     rdfs:label "Jostabeere"@de,
@@ -3468,6 +3496,13 @@ cultivationtype:8 a owl:Class ;
         "Terreni da strame"@it ;
     rdfs:subClassOf :Cultivation .
 
+cultivationtype:80 a owl:Class ;
+    rdfs:label "Schwarze Maulbeere"@de,
+        "Black mulberry"@en,
+        "mûrier noir"@fr,
+        "Moro nero"@it ;
+    rdfs:subClassOf cultivationtype:719 .
+
 cultivationtype:801 a owl:Class ;
     rdfs:label "Gemüsekulturen in Gewächshäusern mit festem Fundament"@de,
         "Cultures maraîchères sous abri avec fondations permanentes"@fr,
@@ -3633,6 +3668,13 @@ cultivationtype:87 a owl:Class ;
         "chou frisé non pommé"@fr,
         "Cavolo piuma"@it ;
     rdfs:subClassOf cultivationtype:20 .
+
+cultivationtype:88 a owl:Class ;
+    rdfs:label "Speise- und Futterkartoffeln"@de,
+        "Table and fodder potatoes"@en,
+        "pommes de terre de consommation et fourragère"@fr,
+        "Patate da tavola e da foraggio"@it ;
+    rdfs:subClassOf cultivationtype:410 .
 
 cultivationtype:89 a owl:Class ;
     rdfs:label "Speisezwiebel"@de,
@@ -3803,6 +3845,13 @@ cultivationtype:929 a owl:Class ;
         "Autres éléments (qualité du paysage)"@fr,
         "Altri elementi (qualità del paesaggio)"@it ;
     rdfs:subClassOf cultivationtype:20 .
+
+cultivationtype:93 a owl:Class ;
+    rdfs:label "Sanddorn"@de,
+        "Sea buckthorn"@en,
+        "Argousier"@fr,
+        "Olivello spinoso"@it ;
+    rdfs:subClassOf cultivationtype:1158 .
 
 cultivationtype:930 a owl:Class ;
     rdfs:label "Sömmerungsweiden"@de,


### PR DESCRIPTION
All remaining PSM crops are essentially *non-crops*...

``` rq
PREFIX : <https://agriculture.ld.admin.ch/crops/>
PREFIX psm: <https://agriculture.ld.admin.ch/crops/psm/1/>
PREFIX cube: <https://cube.link/>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX schema: <http://schema.org/>
SELECT *
FROM <https://lindas.admin.ch/foag/crops>
WHERE {
  ?observation ^cube:observation psm:ObservationSet ;
    schema:name ?name .
  FILTER(LANG(?name)="de")
  MINUS {
    ?observation :cultivationType / rdfs:subClassOf* :Cultivation .
  }
}
```