### PR TITLE
Add a OWL reasoning test

### DIFF
--- a/.github/workflows/graph-pipeline.yml
+++ b/.github/workflows/graph-pipeline.yml
@@ -16,6 +16,7 @@ jobs:
         test-file: 
           - tests/test_turtle_syntax.py
           - tests/test_psm_polyhierarchy_consistency.py
+          - tests/test_owl_consistency.py
     
     steps:
       - name: Checkout Repository

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -757,7 +757,7 @@ cultivationtype:124 a owl:Class ;
     schema:name "Bohnen mit Hülsen"@de,
         "haricots non écossés"@fr,
         "Fagioli con baccello"@it ;
-    rdfs:subClassOf cultivationtype:3 .
+    rdfs:subClassOf cultivationtype:22 .
 
 cultivationtype:125 a owl:Class ;
     schema:name "Quitte"@de,
@@ -1855,7 +1855,6 @@ cultivationtype:468 a owl:Class ;
 
 cultivationtype:469 a owl:Class ;
     schema:name "Freiland-Beeren"@de ;
-    rdfs:subClassOf cultivationtype:830 ;
     owl:unionOf ( cultivationtype:551 cultivationtype:705 ).
 
 cultivationtype:470 a owl:Class ;

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -480,8 +480,7 @@ cultivationtype:69 a owl:Class ;
     schema:name "Mini-Kiwi"@de,
         "mini-Kiwi (Kiwaï)"@fr,
         "Mini-Kiwi"@it ;
-    rdfs:subClassOf cultivationtype:471,
-        cultivationtype:731 .
+    rdfs:subClassOf cultivationtype:731 .
 
 cultivationtype:72 a owl:Class ;
     schema:name "Bäume und Sträucher (ausserhalb Forst)"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -433,7 +433,7 @@ cultivationtype:58 a owl:Class ;
     schema:name "Chinakohl"@de,
         "chou de Chine"@fr,
         "Cavolo cinese"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:475 .
 
 cultivationtype:60 a owl:Class ;
     schema:name "Sommerflor"@de,
@@ -562,7 +562,7 @@ cultivationtype:87 a owl:Class ;
     schema:name "Federkohl"@de,
         "chou frisé non pommé"@fr,
         "Cavolo piuma"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:475 .
 
 cultivationtype:88 a owl:Class ;
     schema:name "Speise- und Futterkartoffeln"@de,
@@ -986,7 +986,7 @@ cultivationtype:171 a owl:Class ;
     schema:name "Bohnen ohne Hülsen"@de,
         "Haricots écossés"@fr,
         "Fagioli senza baccello"@it ;
-    rdfs:subClassOf cultivationtype:3 .
+    rdfs:subClassOf cultivationtype:476 .
 
 cultivationtype:172 a owl:Class ;
     schema:name "Lorbeer"@de,
@@ -1272,7 +1272,7 @@ cultivationtype:237 a owl:Class ;
     schema:name "Markstammkohl"@de,
         "chou moellier"@fr,
         "Cavolo fustoso"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:475 .
 
 cultivationtype:238 a owl:Class ;
     schema:name "Nelken"@de,
@@ -1693,7 +1693,7 @@ cultivationtype:325 a owl:Class ;
     schema:name "Pak-Choi"@de,
         "pakchoi"@fr,
         "Pak-Choi"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:475 .
 
 cultivationtype:326 a owl:Class ;
     schema:name "Rubus Arten"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -1222,18 +1222,6 @@ cultivationtype:1195 a owl:Class ;
         "Erbe aromatiche, perenni, piccole"@it ;
     rdfs:subClassOf cultivationtype:1287 .
 
-cultivationtype:1198 a owl:Class ;
-    rdfs:label "Vom Betrieb weggeführtes Rübenblatt"@de,
-        "Beet leaves exported from farm"@en,
-        "Feuilles de betteraves exportées de l'exploitation"@fr,
-        "Foglie di barbabietola esportate dall'azienda"@it .
-
-cultivationtype:1199 a owl:Class ;
-    rdfs:label "Kleine Anlagen (<20 a) mit versch. Dauerkulturen"@de,
-        "Small installations (<20 a) with various permanent crops"@en,
-        "Petites installations (<20 a) avec diverses cultures permanentes"@fr,
-        "Piccoli impianti (<20 a) con diverse colture permanenti"@it .
-
 cultivationtype:12 a owl:Class ;
     rdfs:label "Flächen ausserhalb der landwirtschaftlichen Nutzfläche"@de,
         "Surfaces en dehors de la surface agricole utile"@fr,
@@ -1253,30 +1241,12 @@ cultivationtype:1200 a owl:Class ;
         "Cavolo rapa da trasformazione"@it ;
     rdfs:subClassOf cultivationtype:86 .
 
-cultivationtype:1202 a owl:Class ;
-    rdfs:label "Kleesamenproduktion"@de,
-        "Clover seed production"@en,
-        "Production de semences de trèfle"@fr,
-        "Produzione di sementi di trifoglio"@it .
-
-cultivationtype:1203 a owl:Class ;
-    rdfs:label "Gründüngung Leguminosen (Freilandgemüse)"@de,
-        "Green manure legumes (open field vegetables)"@en,
-        "Engrais vert légumineuses (légumes de plein champ)"@fr,
-        "Sovescio leguminose (ortaggi in pieno campo)"@it .
-
 cultivationtype:1204 a owl:Class ;
     rdfs:label "Nussbäume, 0.01 ha/Baum"@de,
         "Walnut trees, 0.01 ha/tree"@en,
         "Noyers, 0.01 ha/arbre"@fr,
         "Noci, 0.01 ha/albero"@it ;
     rdfs:subClassOf cultivationtype:922 .
-
-cultivationtype:1205 a owl:Class ;
-    rdfs:label "betriebseigenes verfütt. Rübenblatt"@de,
-        "Home-grown fed beet leaves"@en,
-        "Feuilles de betteraves fourragères de l'exploitation"@fr,
-        "Foglie di barbabietola foraggera dell'azienda"@it .
 
 cultivationtype:1206 a owl:Class ;
     rdfs:label "Einjährige Erdbeeren"@de ;
@@ -1379,12 +1349,6 @@ cultivationtype:122 a owl:Class ;
     rdfs:subClassOf cultivationtype:118,
         cultivationtype:72 .
 
-cultivationtype:1220 a owl:Class ;
-    rdfs:label "Vom Betrieb weggeführtes Stroh"@de,
-        "Straw exported from farm"@en,
-        "Paille exportée de l'exploitation"@fr,
-        "Paglia esportata dall'azienda"@it .
-
 cultivationtype:1221 a owl:Class ;
     rdfs:label "Erdbeeren 1-jährig, 2.0 kg/m2"@de,
         "Strawberries 1-year, 2.0 kg/m2"@en,
@@ -1398,12 +1362,6 @@ cultivationtype:1222 a owl:Class ;
         "Fraises annuelles, 4.0 kg/m2"@fr,
         "Fragole annuali, 4.0 kg/m2"@it ;
     rdfs:subClassOf cultivationtype:1206 .
-
-cultivationtype:1223 a owl:Class ;
-    rdfs:label "Nicht aufgef. Ackerkult., Nicht-Leg.,Mischungen Leg.+Nicht-Leg"@de,
-        "Unlisted arable crops, non-legumes, mixtures legumes+non-legumes"@en,
-        "Cultures des champs non listées, non-lég., mélanges lég.+non-lég."@fr,
-        "Colture campestri non elencate, non leguminose, miscele leguminose+non leguminose"@it .
 
 cultivationtype:1224 a owl:Class ;
     rdfs:label "Winterspinat, 1 Schnitt"@de,
@@ -1486,7 +1444,7 @@ cultivationtype:124 a owl:Class ;
     rdfs:label "Bohnen mit Hülsen"@de,
         "haricots non écossés"@fr,
         "Fagioli con baccello"@it ;
-    rdfs:subClassOf cultivationtype:3 .
+    rdfs:subClassOf cultivationtype:22 .
 
 cultivationtype:1240 a owl:Class ;
     rdfs:label "Kamille"@de,
@@ -1685,18 +1643,6 @@ cultivationtype:1273 a owl:Class ;
         "Uva spina, 2.5 kg/m2"@it ;
     rdfs:subClassOf cultivationtype:298 .
 
-cultivationtype:1275 a owl:Class ;
-    rdfs:label "Gründüngung (Leguminosen)"@de,
-        "Green manure (legumes)"@en,
-        "Engrais vert (légumineuses)"@fr,
-        "Sovescio (leguminose)"@it .
-
-cultivationtype:1277 a owl:Class ;
-    rdfs:label "Gründüngung (Nichtleguminosen)"@de,
-        "Green manure (non-legumes)"@en,
-        "Engrais vert (non-légumineuses)"@fr,
-        "Sovescio (non leguminose)"@it .
-
 cultivationtype:1278 a owl:Class ;
     rdfs:label "Stachelbeeren, 1.7 kg/m2"@de,
         "Gooseberries, 1.7 kg/m2"@en,
@@ -1731,12 +1677,6 @@ cultivationtype:1284 a owl:Class ;
         "Arbres fruitiers à haute tige, 0.01ha/arbre"@fr,
         "Alberi da frutto ad alto fusto, 0.01ha/albero"@it ;
     rdfs:subClassOf cultivationtype:921 .
-
-cultivationtype:1285 a owl:Class ;
-    rdfs:label "Hecken und Feldgehölz mit Krautsaum"@de,
-        "Hedges and field copses with herbaceous margin"@en,
-        "Haies et bosquets champêtres avec ourlet herbacé"@fr,
-        "Siepi e boschetti campestri con margine erbaceo"@it .
 
 cultivationtype:1286 a owl:Class ;
     rdfs:label "Einjährige Kräuter"@de ;
@@ -1817,7 +1757,7 @@ cultivationtype:14 a owl:Class ;
     rdfs:label "Getreide"@de,
         "Céréales"@fr,
         "Cereali"@it ;
-    rdfs:comment "Der Anbau von verschiedenen Getreidearten wie Weizen, Gerste, Roggenfer oder Dinkel. Das Hauptziel ist die Gewinnung der Körner zur Nutzung als Lebens- oder Futtermittel."@de ;
+    rdfs:comment "Der Anbau von verschiedenen Getreidearten wie Weizen, Gerste, Roggen, Hafer oder Dinkel. Das Hauptziel ist die Gewinnung der Körner zur Nutzung als Lebens- oder Futtermittel."@de ;
     rdfs:subClassOf cultivationtype:1032 .
 
 cultivationtype:140 a owl:Class ;
@@ -3034,7 +2974,6 @@ cultivationtype:468 a owl:Class ;
 
 cultivationtype:469 a owl:Class ;
     rdfs:label "Freiland-Beeren"@de ;
-    rdfs:subClassOf cultivationtype:830 ;
     owl:unionOf ( cultivationtype:551 cultivationtype:705 ) .
 
 cultivationtype:47 a owl:Class ;
@@ -3863,8 +3802,7 @@ cultivationtype:69 a owl:Class ;
     rdfs:label "Mini-Kiwi"@de,
         "mini-Kiwi (Kiwaï)"@fr,
         "Mini-Kiwi"@it ;
-    rdfs:subClassOf cultivationtype:471,
-        cultivationtype:731 .
+    rdfs:subClassOf cultivationtype:731 .
 
 cultivationtype:693 a owl:Class ;
     rdfs:label "Regionsspezifische Biodiversitätsförderflächen (Weiden)"@de,

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -28,3 +28,4 @@ urllib3==2.6.3
 SPARQLWrapper==2.0.0
 pyshacl==0.30.1
 owlready2==0.50
+pathlib==1.0.1

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -27,3 +27,4 @@ tzdata==2026.1
 urllib3==2.6.3
 SPARQLWrapper==2.0.0
 pyshacl==0.30.1
+owlready2==0.50

--- a/tests/test_owl_consistency.py
+++ b/tests/test_owl_consistency.py
@@ -26,7 +26,7 @@ def translated_ontology_path():
         pytest.fail(f"rdflib failed to parse the TTL file. Syntax error: {e}")
 
     # 3. Create a temporary file for the RDF/XML translation
-    # mkstemp returns a file descriptor and an absolute path
+    #    mkstemp returns a file descriptor and an absolute path
     fd, temp_path = tempfile.mkstemp(suffix=".xml")
     os.close(fd) 
 
@@ -48,7 +48,9 @@ def test_cultivation_types_consistency(translated_ontology_path):
     """
     # 1. Load into Owlready2
     try:
-        onto = get_ontology(f"file://{translated_ontology_path}").load()
+        # Generate a valid RFC 8089 file URI to prevent Owlready string type errors
+        onto_uri = Path(translated_ontology_path).resolve().as_uri()
+        onto = get_ontology(onto_uri).load()
     except Exception as e:
         pytest.fail(f"Owlready2 failed to load the translated ontology: {e}")
 
@@ -60,8 +62,8 @@ def test_cultivation_types_consistency(translated_ontology_path):
         pytest.fail(f"Ontology data is INCONSISTENT. Reasoner output: {e}")
 
     # 3. Check for Unsatisfiable Classes (Catches TBox schema errors)
-    # Any class with contradictory definitions (like being a subclass of a disjoint class) 
-    # silently becomes a subclass of owl:Nothing during reasoning.
+    #    Any class with contradictory definitions (like being a subclass of a disjoint class) 
+    #    silently becomes a subclass of owl:Nothing during reasoning.
     unsatisfiable_classes = list(onto.classes())
     broken_classes = [cls for cls in unsatisfiable_classes if Nothing in cls.ancestors()]
 

--- a/tests/test_owl_consistency.py
+++ b/tests/test_owl_consistency.py
@@ -1,0 +1,72 @@
+import os
+import tempfile
+import pytest
+from rdflib import Graph
+from owlready2 import get_ontology, sync_reasoner, OwlReadyInconsistentOntologyError, Nothing
+
+# Define the path to your ontology
+TTL_FILE_PATH = "rdf/ontology/cultivationtypes.ttl"
+
+@pytest.fixture
+def translated_ontology_path():
+    """
+    Fixture: Parses the TTL file with rdflib, translates it to RDF/XML, 
+    saves it to a temporary file, and yields the file path to the test.
+    Cleans up the temporary file automatically after the test finishes.
+    """
+    # 1. Ensure the file exists before testing
+    assert os.path.exists(TTL_FILE_PATH), f"Ontology file not found at: {TTL_FILE_PATH}"
+
+    # 2. Parse with rdflib
+    g = Graph()
+    try:
+        g.parse(TTL_FILE_PATH, format="turtle")
+    except Exception as e:
+        pytest.fail(f"rdflib failed to parse the TTL file. Syntax error: {e}")
+
+    # 3. Create a temporary file for the RDF/XML translation
+    # mkstemp returns a file descriptor and an absolute path
+    fd, temp_path = tempfile.mkstemp(suffix=".xml")
+    os.close(fd) 
+
+    # Serialize and yield to the test
+    try:
+        g.serialize(destination=temp_path, format="xml")
+        yield temp_path
+        
+    # 4. Teardown: Clean up the temporary file so it doesn't clutter your system
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+
+
+def test_cultivation_types_consistency(translated_ontology_path):
+    """
+    Test: Loads the RDF/XML ontology into Owlready2, runs the HermiT reasoner,
+    and asserts both ABox consistency and TBox satisfiability.
+    """
+    # 1. Load into Owlready2
+    try:
+        onto = get_ontology(f"file://{translated_ontology_path}").load()
+    except Exception as e:
+        pytest.fail(f"Owlready2 failed to load the translated ontology: {e}")
+
+    # 2. Run the reasoner (Catches ABox data contradictions)
+    try:
+        with onto:
+            sync_reasoner()
+    except OwlReadyInconsistentOntologyError as e:
+        pytest.fail(f"Ontology data is INCONSISTENT. Reasoner output: {e}")
+
+    # 3. Check for Unsatisfiable Classes (Catches TBox schema errors)
+    # Any class with contradictory definitions (like being a subclass of a disjoint class) 
+    # silently becomes a subclass of owl:Nothing during reasoning.
+    unsatisfiable_classes = list(onto.classes())
+    broken_classes = [cls for cls in unsatisfiable_classes if Nothing in cls.ancestors()]
+
+    if broken_classes:
+        class_names = [cls.name for cls in broken_classes]
+        pytest.fail(
+            f"Ontology logic is invalid: Found UNSATISFIABLE classes (empty sets due to contradictory axioms). "
+            f"Broken classes: {class_names}"
+        )

--- a/tests/test_owl_consistency.py
+++ b/tests/test_owl_consistency.py
@@ -3,9 +3,10 @@ import tempfile
 import pytest
 from rdflib import Graph
 from owlready2 import get_ontology, sync_reasoner, OwlReadyInconsistentOntologyError, Nothing
+from pathlib import Path
 
-# Define the path to your ontology
-TTL_FILE_PATH = "rdf/ontology/cultivationtypes.ttl"
+BASE_DIR = Path(__file__).resolve().parent.parent
+TTL_FILE_PATH = BASE_DIR / "rdf" / "ontology" / "cultivationtypes.ttl"
 
 @pytest.fixture
 def translated_ontology_path():

--- a/tests/test_owl_consistency.py
+++ b/tests/test_owl_consistency.py
@@ -66,10 +66,8 @@ def test_cultivation_types_consistency(translated_ontology_path):
     #    silently becomes a subclass of owl:Nothing during reasoning.
     unsatisfiable_classes = list(onto.classes())
     broken_classes = [cls for cls in unsatisfiable_classes if Nothing in cls.ancestors()]
-
-    if broken_classes:
-        class_names = [cls.name for cls in broken_classes]
-        pytest.fail(
-            f"Ontology logic is invalid: Found UNSATISFIABLE classes (empty sets due to contradictory axioms). "
-            f"Broken classes: {class_names}"
-        )
+    assert not broken_classes, (
+        f"Ontology logic is invalid: Found UNSATISFIABLE classes "
+        f"(empty sets due to contradictory axioms). "
+        f"Broken classes: {[cls.name for cls in broken_classes]}"
+    )


### PR DESCRIPTION
## New test to expose logical flaws in the ontology

This PR includes a new test `tests/test_ontology.py` that runs on each PR. It uses the HermiT reasoner to check our OWL ontology for logical contradictions (both in the assertion box and taxonomy box; so no instantiation is needed for the validation).

Run the test using

``` bash
pip install -r src/python/requirements.txt
pytest tests/test_ontology.py
```

It should find any logical flaws in `rdf/ontology/cultivationtypes.ttl`, e.g.

``` ttl
:A a owl:Class ; owl:disjointWith :B .
:B a owl:Class .
:C a owl:Class ; rdfs:subClassOf :A, :B .
```

(This statement is only satisfiable if `:C` is equivalent to `owl:Nothing`, i.e. $C = \emptyset$, which I explicitly disallowed, as it doesn't make sense for us to define empty classes.)

## OWL consistency fixes

Running this test exposed several classes due to conflicting definitions higher up in the taxonomy:

### Problems with `cultivationtype:469` "Freiland-Beeren"

`cultivationtype:469` (Freiland-Beeren) was (mistakenly) defined as a subclass of `cultivationtype:830` (Kulturen in ganzjährig geschütztem Anbau / protected cultivation). At the same time, it was defined as a union of `cultivationtype:551` (open-field) and `cultivationtype:705` (permanent crop). The top-level axioms strictly define open-field (`cultivationtype:1`) and permanent crops (`cultivationtype:6`) as mathematically disjoint from protected cultivation (`cultivationtype:7`). Because `cultivationtype:469` tried to bridge these disjoint categories, the reasoner flagged it as logically impossible.

### Problems with `cultivationtype:1081` "Stangenbohne im geschützten Anbau"

`cultivationtype:1081` (Stangenbohne im geschützten Anbau) was defined as an intersection of `cultivationtype:201` (Stangenbohne) and `cultivationtype:7` (Geschützter Anbau). Further up the tree, `cultivationtype:201` inherited from `cultivationtype:124` (Bohnen mit Hülsen), which was incorrectly classified under `cultivationtype:3` (Dauerweiden / Permanent pastures). Because the root axioms state that permanent pastures (`cultivationtype:21`) and protected cultivation (`cultivationtype:7`) are mutually exclusive, the reasoner found it impossible for an instance to exist in both simultaneously, breaking the class.

### Problems with mini-kiwis

Closes blw-ofag-ufag/eCH-0265#345

`cultivationtype:69` (Mini-Kiwis) was defined as both a fruit crop `cultivationtype:5` as well as a berry crop `cultivationtype:471`. This definition comes from the Swiss registry of plant protection products, but it causes issues because in AGIS, fruits and berries are disjoint.