### PR TITLE
Various minor changes

### DIFF
--- a/docs/hierarchy/main.js
+++ b/docs/hierarchy/main.js
@@ -155,7 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
             OPTIONAL {
-                VALUES ?attributeType { :intensity :purpose :cultivationMethod }
+                VALUES ?attributeType { :managementIntensity :purpose :cultivationMethod }
                 ?node ?attributeType ?attributeValue .
                 BIND(BNODE() AS ?attribute)
                 ?attributeType schema:name ?attributeTypeName .

--- a/rdf/ontology/core.ttl
+++ b/rdf/ontology/core.ttl
@@ -198,6 +198,7 @@ schema:isPartOf a owl:ObjectProperty ;
 :intensity a owl:ObjectProperty ;
     schema:name "Anbauintensität"@de,
         "Cultivation intensity"@en ;
+    schema:description "Anbauintensität, mit welcher Flächen der Bezugsklasse bewirtschaftet werden."@de ;
     rdfs:domain :CultivationType ;
     rdfs:range [ owl:oneOf ( :21 :22 :23 :24 ) ] .
 

--- a/rdf/ontology/core.ttl
+++ b/rdf/ontology/core.ttl
@@ -1,4 +1,5 @@
 @prefix : <https://agriculture.ld.admin.ch/crops/> .
+@prefix intensity: <https://agriculture.ld.admin.ch/crops/intensity/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -200,7 +201,7 @@ schema:isPartOf a owl:ObjectProperty ;
         "Cultivation intensity"@en ;
     schema:description "Anbauintensität, mit welcher Flächen der Bezugsklasse bewirtschaftet werden."@de ;
     rdfs:domain :CultivationType ;
-    rdfs:range [ owl:oneOf ( :21 :22 :23 :24 ) ] .
+    rdfs:range [ owl:oneOf ( intensity:Extensive intensity:Low intensity:Medium intensity:Intensive ) ] .
 
 :memberOfClass a owl:ObjectProperty ;
     schema:name "Klasse"@de,

--- a/rdf/ontology/core.ttl
+++ b/rdf/ontology/core.ttl
@@ -8,32 +8,32 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 wikidata:Q16521 a owl:Class ;
-    rdfs:label "Biologisches Taxon"@de,
+    schema:name "Biologisches Taxon"@de,
         "Biological taxon"@en .
 
 :Area a owl:Class ;
-    rdfs:label "Fläche"@de ;
+    schema:name "Fläche"@de ;
     rdfs:subClassOf :Geometry .
 
 :Cultivation a owl:Class ;
-    rdfs:label "Nutzung"@de,
+    schema:name "Nutzung"@de,
         "Cultivation"@en ;
-    rdfs:comment "Represents a specific, spatio-temporally bound agricultural event. It models a single cultivation cycle of a particular crop on a defined area with start and end dates. For example, 'the 2023 summer wheat cultivation on field X12B3', as distinct from the general concept of 'wheat cultivation'."@en ;
+    schema:description "Represents a specific, spatio-temporally bound agricultural event. It models a single cultivation cycle of a particular crop on a defined area with start and end dates. For example, 'the 2023 summer wheat cultivation on field X12B3', as distinct from the general concept of 'wheat cultivation'."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:onProperty schema:event ;
             owl:someValuesFrom schema:Event ] .
 
 :CultivationType a owl:Class ;
-    rdfs:label "Nutzungsart"@de,
+    schema:name "Nutzungsart"@de,
         "Cultivation type"@en ;
-    rdfs:comment "The cultivation type helps group (agronomically) similar instances of cultivations together. It is a union of crop definitions from direct payments crops, principles of fertilisation of agricultural crops in Switzerland (GRUD), crops in the Swiss registry of plant protection and others. The cultivation type is distinct from the botanical plant, because it is used to classifiy cultivations, not individual plants."@en .
+    schema:description "The cultivation type helps group (agronomically) similar instances of cultivations together. It is a union of crop definitions from direct payments crops, principles of fertilisation of agricultural crops in Switzerland (GRUD), crops in the Swiss registry of plant protection and others. The cultivation type is distinct from the botanical plant, because it is used to classifiy cultivations, not individual plants."@en .
 
 :Geometry a owl:Class ;
-    rdfs:label "Geometrie"@de,
+    schema:name "Geometrie"@de,
         "Geometry"@en .
 
 :Identifier a owl:Class ;
-    rdfs:label "Identifikator"@de,
+    schema:name "Identifikator"@de,
         "Identifier"@en ;
     rdfs:subClassOf
         [ 
@@ -48,128 +48,128 @@ wikidata:Q16521 a owl:Class ;
         ] .
 
 :Point a owl:Class ;
-    rdfs:label "Punkt"@de ;
+    schema:name "Punkt"@de ;
     rdfs:subClassOf :Geometry .
 
 :Taxon a owl:Class ;
-    rdfs:label "Biologisches Taxon der Kulturpflanze"@de,
+    schema:name "Biologisches Taxon der Kulturpflanze"@de,
         "Crop taxon"@en ;
-    rdfs:comment "A crop is a plant that can be grown and harvested extensively for profit or subsistence. The class of crop taxa hence contains all biological taxa of crops, for example *Triticum aestivum* or *Glycine max*."@en ;
+    schema:description "A crop is a plant that can be grown and harvested extensively for profit or subsistence. The class of crop taxa hence contains all biological taxa of crops, for example *Triticum aestivum* or *Glycine max*."@en ;
     rdfs:subClassOf wikidata:Q16521 .
 
 :1 a owl:NamedIndividual ;
-    rdfs:label "Menschliche Ernährung"@de,
+    schema:name "Menschliche Ernährung"@de,
         "Human nutrition"@en .
 
 :11 a owl:NamedIndividual ;
-    rdfs:label "Freiland"@de,
+    schema:name "Freiland"@de,
         "Outdoor cultivation"@en .
 
 :12 a owl:NamedIndividual ;
-    rdfs:label "geschützter Anbau"@de,
+    schema:name "geschützter Anbau"@de,
         "Protected cultivation"@en .
 
 :13 a owl:NamedIndividual ;
-    rdfs:label "in Gewächshäusern"@de,
+    schema:name "in Gewächshäusern"@de,
         "In greenhouses"@en .
 
 :14 a owl:NamedIndividual ;
-    rdfs:label "im gewachsenen Boden"@de,
+    schema:name "im gewachsenen Boden"@de,
         "In native soil"@en .
 
 :15 a owl:NamedIndividual ;
-    rdfs:label "auf Pflanztischen oder -gestellen"@de,
+    schema:name "auf Pflanztischen oder -gestellen"@de,
         "On plant tables or racks"@en .
 
 :16 a owl:NamedIndividual ;
-    rdfs:label "mit festem Fundament"@de,
+    schema:name "mit festem Fundament"@de,
         "With permanent foundation"@en .
 
 :17 a owl:NamedIndividual ;
-    rdfs:label "ohne festes Fundament"@de,
+    schema:name "ohne festes Fundament"@de,
         "Without permanent foundation"@en .
 
 :2 a owl:NamedIndividual ;
-    rdfs:label "Tierische Ernährung"@de,
+    schema:name "Tierische Ernährung"@de,
         "Animal nutrition"@en .
 
 :21 a owl:NamedIndividual ;
-    rdfs:label "extensiv"@de,
+    schema:name "extensiv"@de,
         "Extensive"@en .
 
 :22 a owl:NamedIndividual ;
-    rdfs:label "wenig intensiv"@de,
+    schema:name "wenig intensiv"@de,
         "Low intensity"@en .
 
 :23 a owl:NamedIndividual ;
-    rdfs:label "mittelintensiv"@de,
+    schema:name "mittelintensiv"@de,
         "Medium intensity"@en .
 
 :24 a owl:NamedIndividual ;
-    rdfs:label "intensiv"@de,
+    schema:name "intensiv"@de,
         "Intensive"@en .
 
 :3 a owl:NamedIndividual ;
-    rdfs:label "Bioenergie"@de,
+    schema:name "Bioenergie"@de,
         "Bioenergy"@en .
 
 :4 a owl:NamedIndividual ;
-    rdfs:label "Industrielle Rohstoffe"@de,
+    schema:name "Industrielle Rohstoffe"@de,
         "Industrial materials"@en .
 
 :5 a owl:NamedIndividual ;
-    rdfs:label "Saatgutproduktion"@de,
+    schema:name "Saatgutproduktion"@de,
         "Seed production"@en .
 
 :6 a owl:NamedIndividual ;
-    rdfs:label "Bodenverbesserung"@de,
+    schema:name "Bodenverbesserung"@de,
         "Soil improvement"@en .
 
 schema:event a owl:ObjectProperty ;
-    rdfs:label "Ereignis"@de,
+    schema:name "Ereignis"@de,
         "Event"@en .
 
 schema:hasPart a owl:ObjectProperty ;
-    rdfs:label "hat Teil"@de,
+    schema:name "hat Teil"@de,
         "has part"@en ;
     owl:inverseOf schema:isPartOf .
 
 schema:identifier a owl:ObjectProperty ;
-    rdfs:label "Identifikator"@de,
+    schema:name "Identifikator"@de,
         "Identifier"@en ;
     rdfs:range :Identifier .
 
 schema:isPartOf a owl:ObjectProperty ;
-    rdfs:label "ist Teil von"@de,
+    schema:name "ist Teil von"@de,
         "is part of"@en ;
     owl:inverseOf schema:hasPart .
 
 :area a owl:ObjectProperty ;
-    rdfs:label "Bedeckt Fläche"@de,
+    schema:name "Bedeckt Fläche"@de,
         "Covers area"@en ;
-    rdfs:comment "The area that is covered/used by a cultivation"@en ;
+    schema:description "The area that is covered/used by a cultivation"@en ;
     rdfs:domain :Cultivation ;
     rdfs:range :Area .
 
 :botanicalPlant a owl:ObjectProperty ;
-    rdfs:label "Botanical plant"@en ;
-    rdfs:comment "One or more botanical plant taxa that specify a given cultivation type. For example, \"winter wheat\" has botanical plant *Triticum aestivum*. Note that while the first describes a form (class) of cultivations, the latter describes a class of plant individuals."@en ;
+    schema:name "Botanical plant"@en ;
+    schema:description "One or more botanical plant taxa that specify a given cultivation type. For example, \"winter wheat\" has botanical plant *Triticum aestivum*. Note that while the first describes a form (class) of cultivations, the latter describes a class of plant individuals."@en ;
     rdfs:domain :CultivationType ;
     rdfs:range :Taxon .
 
 :cultivationMethod a owl:ObjectProperty ;
-    rdfs:label "Anbaumethode"@de ;
+    schema:name "Anbaumethode"@de ;
     rdfs:domain :CultivationType ;
     rdfs:range [ owl:oneOf ( :11 :12 :13 :14 :15 :16 :17 ) ] .
 
 :cultivationType a owl:ObjectProperty ;
-    rdfs:label "Cultivation type"@en ;
-    rdfs:comment "The cultivation type that classifies a certain cultivation."@en ;
+    schema:name "Cultivation type"@en ;
+    schema:description "The cultivation type that classifies a certain cultivation."@en ;
     rdfs:domain :Cultivation ;
     rdfs:range :CultivationType .
 
 :eligibleFor a owl:ObjectProperty ;
-    rdfs:label "ist beitragsberechtigt für"@de ;
+    schema:name "ist beitragsberechtigt für"@de ;
     rdfs:domain :DirectPaymentCrop ;
     rdfs:range :DirectPaymentPrograms .
 
@@ -178,56 +178,56 @@ schema:isPartOf a owl:ObjectProperty ;
     rdfs:range :FertilisationStandard .
 
 :hasMembership a owl:ObjectProperty ;
-    rdfs:label "Klassenzugehörigkeit"@de,
+    schema:name "Klassenzugehörigkeit"@de,
         "Class membership"@en ;
     rdfs:range :ClassMembership .
 
 :hasPart a owl:ObjectProperty ;
-    rdfs:label "Unterkategorie"@de,
+    schema:name "Unterkategorie"@de,
         "Sub-category"@en ;
     rdfs:domain :CultivationType ;
     rdfs:range :CultivationType ;
     owl:inverseOf :partOf .
 
 :includes a owl:ObjectProperty ;
-    rdfs:label "beinhaltet"@de,
+    schema:name "beinhaltet"@de,
         "includes"@en ;
     rdfs:domain :Area ;
     rdfs:range :Point .
 
 :intensity a owl:ObjectProperty ;
-    rdfs:label "Anbauintensität"@de,
+    schema:name "Anbauintensität"@de,
         "Cultivation intensity"@en ;
     rdfs:domain :CultivationType ;
     rdfs:range [ owl:oneOf ( :21 :22 :23 :24 ) ] .
 
 :memberOfClass a owl:ObjectProperty ;
-    rdfs:label "Klasse"@de,
+    schema:name "Klasse"@de,
         "Class"@en ;
     rdfs:domain :ClassMembership ;
     rdfs:range owl:Class .
 
 :parentTaxon a owl:ObjectProperty ;
-    rdfs:label "Parent taxon"@en ;
+    schema:name "Parent taxon"@en ;
     rdfs:domain :Taxon ;
     rdfs:range :Taxon .
 
 :partOf a owl:ObjectProperty ;
-    rdfs:label "Überkategorie"@de,
+    schema:name "Überkategorie"@de,
         "Super-category"@en ;
     rdfs:domain :CultivationType ;
     rdfs:range :CultivationType ;
     owl:inverseOf :hasPart .
 
 :purpose a owl:ObjectProperty ;
-    rdfs:label "Verwendungszweck"@de ;
+    schema:name "Verwendungszweck"@de ;
     rdfs:domain :CultivationType ;
     rdfs:range [ owl:oneOf ( :1 :2 :3 :4 :5 :6 ) ] .
 
 :sourceSystem a owl:ObjectProperty .
 
 :taxonRank a owl:ObjectProperty ;
-    rdfs:label "Taxon rank"@en ;
+    schema:name "Taxon rank"@en ;
     rdfs:domain :Taxon ;
     rdfs:range [ owl:oneOf ( :Variety :Subspecies :Species :Genus :Family :Order :Class :Phylum :Kingdom ) ] .
 

--- a/rdf/ontology/core.ttl
+++ b/rdf/ontology/core.ttl
@@ -196,7 +196,7 @@ schema:isPartOf a owl:ObjectProperty ;
     rdfs:domain :Area ;
     rdfs:range :Point .
 
-:intensity a owl:ObjectProperty ;
+:managementIntensity a owl:ObjectProperty ;
     schema:name "Anbauintensität"@de,
         "Cultivation intensity"@en ;
     schema:description "Anbauintensität, mit welcher Flächen der Bezugsklasse bewirtschaftet werden."@de ;

--- a/rdf/ontology/core.ttl
+++ b/rdf/ontology/core.ttl
@@ -94,19 +94,19 @@ wikidata:Q16521 a owl:Class ;
     schema:name "Tierische Ernährung"@de,
         "Animal nutrition"@en .
 
-:21 a owl:NamedIndividual ;
+intensity:Extensive a owl:NamedIndividual ;
     schema:name "extensiv"@de,
         "Extensive"@en .
 
-:22 a owl:NamedIndividual ;
+intensity:Low a owl:NamedIndividual ;
     schema:name "wenig intensiv"@de,
         "Low intensity"@en .
 
-:23 a owl:NamedIndividual ;
+intensity:Medium a owl:NamedIndividual ;
     schema:name "mittelintensiv"@de,
         "Medium intensity"@en .
 
-:24 a owl:NamedIndividual ;
+intensity:Intensive a owl:NamedIndividual ;
     schema:name "intensiv"@de,
         "Intensive"@en .
 

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -81,7 +81,7 @@ cultivationtype:shape a sh:NodeShape ;
         sh:maxCount 1 ;
     ],
     [
-        sh:path :intensity ;
+        sh:path :managementIntensity ;
         sh:nodeKind sh:IRI ;
         sh:maxCount 1 ;
     ],
@@ -2326,14 +2326,14 @@ cultivationtype:555 a owl:Class ;
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:556 a owl:Class ;
     schema:name "Buntbrache"@de,
         "Jachère florale"@fr,
         "Maggese fioriti"@it ;
     rdfs:subClassOf cultivationtype:77 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:557 a owl:Class ;
     schema:name "Rotationsbrache"@de,
@@ -2341,7 +2341,7 @@ cultivationtype:557 a owl:Class ;
         "Maggese da rotazione"@it,
         "Rotational fallow"@en ;
     rdfs:subClassOf cultivationtype:77 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:558 a owl:DeprecatedClass ;
     schema:name "Grünbrache"@de,
@@ -2378,14 +2378,14 @@ cultivationtype:564 a owl:DeprecatedClass ;
         "Bande culturale extensive Oléagineux (colza, tournesols, lin)"@fr,
         "Fasce di colture estensive in campicoltura - semi oleosi (colza, girasole, lino)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:565 a owl:DeprecatedClass ;
     schema:name "Ackerschonstreifen Getreide"@de,
         "Bande culturale extensive céréales"@fr,
         "Fasce di colture estensive in campicoltura - cereali"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:566 a owl:Class ;
     schema:name "Mohn"@de,
@@ -2433,14 +2433,14 @@ cultivationtype:571 a owl:DeprecatedClass ;
         "Bande culturale extensive Légumineuses (féveroles, pois protéagineux, lupins et méteils du code 569)"@fr,
         "Fasce di colture estensive in campicoltura - leguminose a granelli (favette, piselli proteici, lupini e miscele con codice 569)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:572 a owl:Class ;
     schema:name "Nützlingsstreifen auf offener Ackerfläche"@de,
         "avec des céréales ou de la caméline, au moins 30 % de lentilles lors de la récolte (pour la production de grains)"@fr,
         "Strisce per organismi utili sulla superficie coltiva aperta"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:573 a owl:Class ;
     schema:name "Senf"@de,
@@ -2529,7 +2529,7 @@ cultivationtype:594 a owl:Class ;
         "Terres ouvertes donnant droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Superficie coltiva aperta, avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:595 a owl:Class ;
     schema:name "Nicht beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -2539,7 +2539,7 @@ cultivationtype:595 a owl:Class ;
         "Autres terres ouvertes ne donnant pas droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altra superficie coltiva aperta, non avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:597 a owl:Class ;
     schema:name "Beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -2576,7 +2576,7 @@ cultivationtype:611 a owl:Class ;
     "Les prairies exploitées de manière extensive ne sont pas fertilisées et sont fauchées tardivement, comme par exemple les prairies mi-sèches ou à brome. Elles représentent les herbages les plus riches en espèces de Suisse."@fr,
     "I prati sfruttati in modo estensivo non vengono concimati e vengono falciati tardi, come ad esempio i prati semi-aridi o a brometo. Rappresentano le praterie più ricche di specie della Svizzera."@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:612 a owl:Class ;
     schema:name "Wenig intensiv genutzte Wiesen (ohne Weiden)"@de,
@@ -2586,7 +2586,7 @@ cultivationtype:612 a owl:Class ;
     "Les prairies peu intensives sont des prairies légèrement fertilisées et fauchées tardivement, comme par exemple les prairies à fromental ou à avoine dorée."@fr,
     "I prati poco intensivi sono prati leggermente concimati e falciati tardi, come ad esempio i prati a fromental o ad avena bionda."@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity intensity:Low .
+    :managementIntensity intensity:Low .
 
 cultivationtype:613 a owl:Class ;
     schema:name "Übrige Dauerwiesen (ohne Weiden)"@de,
@@ -2605,7 +2605,7 @@ cultivationtype:617 a owl:Class ;
         "Pâturages extensifs"@fr,
         "Pascoli estensivi"@it ;
     rdfs:subClassOf cultivationtype:3 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:618 a owl:Class ;
     schema:name "Waldweiden (ohne bewaldete Fläche)"@de,
@@ -2666,21 +2666,21 @@ cultivationtype:693 a owl:Class ;
         "Surfaces de promotion de la biodiversité spécifiques à la région (pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (pascoli)"@it ;
     rdfs:subClassOf cultivationtype:3 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:694 a owl:Class ;
     schema:name "Regionsspezifische Biodiversitätsförderfläche (Grünflächen ohne Weiden)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère, sauf les pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite, senza pascoli)"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:695 a owl:DeprecatedClass ;
     schema:name "Regionsspezifische Biodiversitätsförderfläche (Grünfläche)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite)"@it ;
     rdfs:subClassOf cultivationtype:21 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:697 a owl:Class ;
     schema:name "Beitragsberechtigte übrige Dauergrünfläche"@de,
@@ -2853,7 +2853,7 @@ cultivationtype:735 a owl:Class ;
     schema:name "Reben (regionsspezifische Biodiversitätsförderflächen)"@de,
         "Vignes (surfaces de promotion de la biodiversité spécifiques à la ré-gion)"@fr,
         "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:750 a owl:Class ;
     schema:name "Übrige beitragsberechtigte Dauerkulturen"@de,
@@ -3008,7 +3008,7 @@ cultivationtype:858 a owl:Class ;
         "Haies, bosquets champêtres et berges boisées (avec la bande tampon) (Surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Siepi, boschetti campestri e rivieraschi (con fascia tampone) (Superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:9 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:895 a owl:Class ;
     schema:name "Dauergrünfläche übrige Flächen innerhalb der LN"@de,
@@ -3082,7 +3082,7 @@ cultivationtype:908 a owl:Class ;
         "Surfaces de promotion de la biodiversité spécifiques à la région"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione"@it ;
     rdfs:subClassOf cultivationtype:12 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:909 a owl:Class ;
     schema:name "Hausgärten"@de,
@@ -3138,14 +3138,14 @@ cultivationtype:927 a owl:Class ;
         "Autres arbres (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri alberi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:20 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:928 a owl:Class ;
     schema:name "Andere Elemente (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres éléments (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri elementi (superficie per la promozione della biodiversità specifica di una regione)"@it ;
     rdfs:subClassOf cultivationtype:20 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:929 a owl:Class ;
     schema:name "Andere Elemente (Landschaftsqualität)"@de,
@@ -3188,7 +3188,7 @@ cultivationtype:950 a owl:Class ;
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
     rdfs:subClassOf :Cultivation ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:951 a owl:Class ;
     schema:name "Getreide in weiter Reihe"@de,
@@ -3330,7 +3330,7 @@ cultivationtype:1021 a owl:Class ;
 cultivationtype:1023 a owl:Class ;
     schema:name "Nützlingsstreifen (DK)"@de ;
     rdfs:subClassOf cultivationtype:6 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:1024 a owl:Class ;
     schema:name "Hecken u. Feldgehölze mit Pufferstreifen (keine BFF)"@de ;
@@ -3417,7 +3417,7 @@ cultivationtype:1041 a owl:Class ;
 cultivationtype:1042 a owl:Class ;
     schema:name "Kunstwiese intensiv"@de, "Prairie artificielle intensive"@fr, "Prato artificiale intensivo"@it ;
     rdfs:subClassOf cultivationtype:601 ;
-    :intensity intensity:Intensive .
+    :managementIntensity intensity:Intensive .
 
 cultivationtype:1043 a owl:Class ;
     schema:name "Kohlrabi (geschützter Anbau)"@de, "Chou-rave (culture protégée)"@fr, "Cavolo rapa (coltura protetta)"@it ;
@@ -3617,7 +3617,7 @@ cultivationtype:1080 a owl:Class ;
     schema:name "Intensive Weiden und Mähweiden"@de ;
     schema:alternateName "Weide (Mäh-) intensiv"@de ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity intensity:Intensive .
+    :managementIntensity intensity:Intensive .
 
 cultivationtype:1081 a owl:Class ;
     schema:name "Stangenbohne (geschützter Anbau)"@de,
@@ -3652,7 +3652,7 @@ cultivationtype:1085 a owl:Class ;
         "Pascoli e pascoli da sfalcio medio-intensivi"@it ;
     schema:alternateName "Weide (Mäh-) mittelintensiv"@de ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity intensity:Medium .
+    :managementIntensity intensity:Medium .
 
 cultivationtype:1086 a owl:Class ;
     schema:name "Schlüsselblume (ganze Pflanze)"@de,
@@ -3909,7 +3909,7 @@ cultivationtype:1126 a owl:Class ;
         "Pâturages peu intensifs"@fr,
         "Pascoli poco intensivi"@it ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity intensity:Low .
+    :managementIntensity intensity:Low .
 
 cultivationtype:1127 a owl:Class ;
     schema:name "Bundzwiebeln, Überwinterung"@de,
@@ -3946,14 +3946,14 @@ cultivationtype:1132 a owl:Class ;
         "Prairies de fauche de la région d'estivage, extensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, estensivi"@it ;
     rdfs:subClassOf cultivationtype:480 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:1133 a owl:Class ;
     schema:name "Heuwiesen Sömmerungsg., wenig intensiv"@de,
         "Prairies de fauche de la région d'estivage, peu intensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, poco intensivi"@it ;
     rdfs:subClassOf cultivationtype:480 ;
-    :intensity intensity:Low .
+    :managementIntensity intensity:Low .
 
 cultivationtype:1134 a owl:Class ;
     schema:name "Heuwiesen im Sömmerungsg., übrige"@de,
@@ -4083,21 +4083,21 @@ cultivationtype:1153 a owl:Class ;
         "Prairie naturelle moyennement intensive"@fr,
         "Prato naturale medio-intensivo"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity intensity:Medium .
+    :managementIntensity intensity:Medium .
 
 cultivationtype:1154 a owl:Class ;
     schema:name "Kunstwiese mittelintensiv"@de,
         "Prairie artificielle moyennement intensive"@fr,
         "Prato artificiale medio-intensivo"@it ;
     rdfs:subClassOf cultivationtype:601 ;
-    :intensity intensity:Medium .
+    :managementIntensity intensity:Medium .
 
 cultivationtype:1155 a owl:Class ;
     schema:name "Naturwiese intensiv"@de,
         "Prairie naturelle intensive"@fr,
         "Prato naturale intensivo"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity intensity:Intensive .
+    :managementIntensity intensity:Intensive .
 
 cultivationtype:1156 a owl:Class ;
     schema:name "Winterspinat, 1 Schnitt"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -3401,7 +3401,8 @@ cultivationtype:1041 a owl:Class ;
 
 cultivationtype:1042 a owl:Class ;
     schema:name "Kunstwiese intensiv"@de, "Prairie artificielle intensive"@fr, "Prato artificiale intensivo"@it ;
-    rdfs:subClassOf cultivationtype:601 .
+    rdfs:subClassOf cultivationtype:601 ;
+    :intensity :24 .
 
 cultivationtype:1043 a owl:Class ;
     schema:name "Kohlrabi (geschützter Anbau)"@de, "Chou-rave (culture protégée)"@fr, "Cavolo rapa (coltura protetta)"@it ;
@@ -3600,7 +3601,8 @@ cultivationtype:1079 a owl:Class ;
 cultivationtype:1080 a owl:Class ;
     schema:name "Intensive Weiden und Mähweiden"@de ;
     schema:alternateName "Weide (Mäh-) intensiv"@de ;
-    rdfs:subClassOf cultivationtype:616 .
+    rdfs:subClassOf cultivationtype:616 ;
+    :intensity :24 .
 
 cultivationtype:1081 a owl:Class ;
     schema:name "Stangenbohne (geschützter Anbau)"@de,
@@ -3634,7 +3636,8 @@ cultivationtype:1085 a owl:Class ;
         "Pâturages et pâturages de fauche moyennement intensifs"@fr,
         "Pascoli e pascoli da sfalcio medio-intensivi"@it ;
     schema:alternateName "Weide (Mäh-) mittelintensiv"@de ;
-    rdfs:subClassOf cultivationtype:616 .
+    rdfs:subClassOf cultivationtype:616 ;
+    :intensity :23 .
 
 cultivationtype:1086 a owl:Class ;
     schema:name "Schlüsselblume (ganze Pflanze)"@de,
@@ -3890,7 +3893,8 @@ cultivationtype:1126 a owl:Class ;
     schema:name "Wenig intensiv genutzte Weiden"@de,
         "Pâturages peu intensifs"@fr,
         "Pascoli poco intensivi"@it ;
-    rdfs:subClassOf cultivationtype:616 .
+    rdfs:subClassOf cultivationtype:616 ;
+    :intensity :22 .
 
 cultivationtype:1127 a owl:Class ;
     schema:name "Bundzwiebeln, Überwinterung"@de,
@@ -3933,7 +3937,8 @@ cultivationtype:1133 a owl:Class ;
     schema:name "Heuwiesen Sömmerungsg., wenig intensiv"@de,
         "Prairies de fauche de la région d'estivage, peu intensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, poco intensivi"@it ;
-    rdfs:subClassOf cultivationtype:480 .
+    rdfs:subClassOf cultivationtype:480 ;
+    :intensity :22 .
 
 cultivationtype:1134 a owl:Class ;
     schema:name "Heuwiesen im Sömmerungsg., übrige"@de,
@@ -4062,19 +4067,22 @@ cultivationtype:1153 a owl:Class ;
     schema:name "Naturwiese mittelintensiv"@de,
         "Prairie naturelle moyennement intensive"@fr,
         "Prato naturale medio-intensivo"@it ;
-    rdfs:subClassOf cultivationtype:2 .
+    rdfs:subClassOf cultivationtype:2 ;
+    :intensity :23 .
 
 cultivationtype:1154 a owl:Class ;
     schema:name "Kunstwiese mittelintensiv"@de,
         "Prairie artificielle moyennement intensive"@fr,
         "Prato artificiale medio-intensivo"@it ;
-    rdfs:subClassOf cultivationtype:601 .
+    rdfs:subClassOf cultivationtype:601 ;
+    :intensity :23 .
 
 cultivationtype:1155 a owl:Class ;
     schema:name "Naturwiese intensiv"@de,
         "Prairie naturelle intensive"@fr,
         "Prato naturale intensivo"@it ;
-    rdfs:subClassOf cultivationtype:2 .
+    rdfs:subClassOf cultivationtype:2 ;
+    :intensity :24 .
 
 cultivationtype:1156 a owl:Class ;
     schema:name "Winterspinat, 1 Schnitt"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -2527,7 +2527,8 @@ cultivationtype:594 a owl:Class ;
     schema:description "Beitragsberechtigte offene Ackerfläche (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Terres ouvertes donnant droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Superficie coltiva aperta, avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:595 a owl:Class ;
     schema:name "Nicht beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -2536,7 +2537,8 @@ cultivationtype:595 a owl:Class ;
     schema:description "Nicht beitragsberechtigte übrige offene Ackerfläche (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres terres ouvertes ne donnant pas droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altra superficie coltiva aperta, non avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:597 a owl:Class ;
     schema:name "Beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -2662,19 +2664,22 @@ cultivationtype:693 a owl:Class ;
     schema:name "Regionsspezifische Biodiversitätsförderflächen (Weiden)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (pascoli)"@it ;
-    rdfs:subClassOf cultivationtype:3 .
+    rdfs:subClassOf cultivationtype:3 ;
+    :intensity :21 .
 
 cultivationtype:694 a owl:Class ;
     schema:name "Regionsspezifische Biodiversitätsförderfläche (Grünflächen ohne Weiden)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère, sauf les pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite, senza pascoli)"@it ;
-    rdfs:subClassOf cultivationtype:2 .
+    rdfs:subClassOf cultivationtype:2 ;
+    :intensity :21 .
 
 cultivationtype:695 a owl:DeprecatedClass ;
     schema:name "Regionsspezifische Biodiversitätsförderfläche (Grünfläche)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite)"@it ;
-    rdfs:subClassOf cultivationtype:21 .
+    rdfs:subClassOf cultivationtype:21 ;
+    :intensity :21 .
 
 cultivationtype:697 a owl:Class ;
     schema:name "Beitragsberechtigte übrige Dauergrünfläche"@de,
@@ -2846,7 +2851,8 @@ cultivationtype:731 a owl:Class ;
 cultivationtype:735 a owl:Class ;
     schema:name "Reben (regionsspezifische Biodiversitätsförderflächen)"@de,
         "Vignes (surfaces de promotion de la biodiversité spécifiques à la ré-gion)"@fr,
-        "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it .
+        "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
+    :intensity :21 .
 
 cultivationtype:750 a owl:Class ;
     schema:name "Übrige beitragsberechtigte Dauerkulturen"@de,
@@ -3000,7 +3006,8 @@ cultivationtype:858 a owl:Class ;
     schema:description "Hecken-, Feld- und Ufergehölze (mit Pufferstreifen) (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Haies, bosquets champêtres et berges boisées (avec la bande tampon) (Surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Siepi, boschetti campestri e rivieraschi (con fascia tampone) (Superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:9 .
+    rdfs:subClassOf cultivationtype:9 ;
+    :intensity :21 .
 
 cultivationtype:895 a owl:Class ;
     schema:name "Dauergrünfläche übrige Flächen innerhalb der LN"@de,
@@ -3073,7 +3080,8 @@ cultivationtype:908 a owl:Class ;
     schema:name "Regionsspezifische Biodiversitätsförderflächen"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione"@it ;
-    rdfs:subClassOf cultivationtype:12 .
+    rdfs:subClassOf cultivationtype:12 ;
+    :intensity :21 .
 
 cultivationtype:909 a owl:Class ;
     schema:name "Hausgärten"@de,
@@ -3128,13 +3136,15 @@ cultivationtype:927 a owl:Class ;
     schema:name "Andere Bäume (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres arbres (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri alberi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:20 ;
+    :intensity :21 .
 
 cultivationtype:928 a owl:Class ;
     schema:name "Andere Elemente (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres éléments (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri elementi (superficie per la promozione della biodiversità specifica di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:20 ;
+    :intensity :21 .
 
 cultivationtype:929 a owl:Class ;
     schema:name "Andere Elemente (Landschaftsqualität)"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -2324,7 +2324,8 @@ cultivationtype:555 a owl:Class ;
     schema:name "Ackerschonstreifen"@de,
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:556 a owl:Class ;
     schema:name "Buntbrache"@de,
@@ -2373,13 +2374,15 @@ cultivationtype:564 a owl:DeprecatedClass ;
     schema:name "Ackerschonstreifen Ölsaaten (Raps, Sonnenblumen, Lein)"@de,
         "Bande culturale extensive Oléagineux (colza, tournesols, lin)"@fr,
         "Fasce di colture estensive in campicoltura - semi oleosi (colza, girasole, lino)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:565 a owl:DeprecatedClass ;
     schema:name "Ackerschonstreifen Getreide"@de,
         "Bande culturale extensive céréales"@fr,
         "Fasce di colture estensive in campicoltura - cereali"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:566 a owl:Class ;
     schema:name "Mohn"@de,
@@ -2426,7 +2429,8 @@ cultivationtype:571 a owl:DeprecatedClass ;
     schema:description "Ackerschonstreifen Körnerleguminosen (Ackerbohnen, Eiweisserbsen, Lupinen und Mischungen mit Code 569)"@de,
         "Bande culturale extensive Légumineuses (féveroles, pois protéagineux, lupins et méteils du code 569)"@fr,
         "Fasce di colture estensive in campicoltura - leguminose a granelli (favette, piselli proteici, lupini e miscele con codice 569)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:572 a owl:Class ;
     schema:name "Nützlingsstreifen auf offener Ackerfläche"@de,
@@ -3169,7 +3173,8 @@ cultivationtype:950 a owl:Class ;
     schema:name "Ackerschonstreifen"@de,
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
-    rdfs:subClassOf :Cultivation .
+    rdfs:subClassOf :Cultivation ;
+    :intensity :21 .
 
 cultivationtype:951 a owl:Class ;
     schema:name "Getreide in weiter Reihe"@de,
@@ -3921,7 +3926,8 @@ cultivationtype:1132 a owl:Class ;
     schema:name "Heuwiesen Sömmerungsg., extensive"@de,
         "Prairies de fauche de la région d'estivage, extensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, estensivi"@it ;
-    rdfs:subClassOf cultivationtype:480 .
+    rdfs:subClassOf cultivationtype:480 ;
+    :intensity :21 .
 
 cultivationtype:1133 a owl:Class ;
     schema:name "Heuwiesen Sömmerungsg., wenig intensiv"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -2548,7 +2548,7 @@ cultivationtype:597 a owl:Class ;
     rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:598 a owl:Class ;
-    schema:name "Nicht beitragsberechtigte Übrige offene Ackerfläche"@de,
+    schema:name "Nicht beitragsberechtigte übrige offene Ackerfläche"@de,
         "Autres terres ouvertes sans contributions"@fr,
         "Altra superficie coltiva aperta, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:1 .

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -2331,14 +2331,16 @@ cultivationtype:556 a owl:Class ;
     schema:name "Buntbrache"@de,
         "Jachère florale"@fr,
         "Maggese fioriti"@it ;
-    rdfs:subClassOf cultivationtype:77 .
+    rdfs:subClassOf cultivationtype:77 ;
+    :intensity :21 .
 
 cultivationtype:557 a owl:Class ;
     schema:name "Rotationsbrache"@de,
         "Jachère tournante"@fr,
         "Maggese da rotazione"@it,
         "Rotational fallow"@en ;
-    rdfs:subClassOf cultivationtype:77 .
+    rdfs:subClassOf cultivationtype:77 ;
+    :intensity :21 .
 
 cultivationtype:558 a owl:DeprecatedClass ;
     schema:name "Grünbrache"@de,
@@ -2436,7 +2438,8 @@ cultivationtype:572 a owl:Class ;
     schema:name "Nützlingsstreifen auf offener Ackerfläche"@de,
         "avec des céréales ou de la caméline, au moins 30 % de lentilles lors de la récolte (pour la production de grains)"@fr,
         "Strisce per organismi utili sulla superficie coltiva aperta"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:573 a owl:Class ;
     schema:name "Senf"@de,
@@ -3315,7 +3318,8 @@ cultivationtype:1021 a owl:Class ;
 
 cultivationtype:1023 a owl:Class ;
     schema:name "Nützlingsstreifen (DK)"@de ;
-    rdfs:subClassOf cultivationtype:6 .
+    rdfs:subClassOf cultivationtype:6 ;
+    :intensity :21 .
 
 cultivationtype:1024 a owl:Class ;
     schema:name "Hecken u. Feldgehölze mit Pufferstreifen (keine BFF)"@de ;

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -1,5 +1,6 @@
 @prefix : <https://agriculture.ld.admin.ch/crops/> .
 @prefix cultivationtype: <https://agriculture.ld.admin.ch/crops/cultivationtype/> .
+@prefix intensity: <https://agriculture.ld.admin.ch/crops/intensity/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix taxon: <https://agriculture.ld.admin.ch/crops/taxon/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -2325,14 +2326,14 @@ cultivationtype:555 a owl:Class ;
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:556 a owl:Class ;
     schema:name "Buntbrache"@de,
         "Jachère florale"@fr,
         "Maggese fioriti"@it ;
     rdfs:subClassOf cultivationtype:77 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:557 a owl:Class ;
     schema:name "Rotationsbrache"@de,
@@ -2340,7 +2341,7 @@ cultivationtype:557 a owl:Class ;
         "Maggese da rotazione"@it,
         "Rotational fallow"@en ;
     rdfs:subClassOf cultivationtype:77 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:558 a owl:DeprecatedClass ;
     schema:name "Grünbrache"@de,
@@ -2377,14 +2378,14 @@ cultivationtype:564 a owl:DeprecatedClass ;
         "Bande culturale extensive Oléagineux (colza, tournesols, lin)"@fr,
         "Fasce di colture estensive in campicoltura - semi oleosi (colza, girasole, lino)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:565 a owl:DeprecatedClass ;
     schema:name "Ackerschonstreifen Getreide"@de,
         "Bande culturale extensive céréales"@fr,
         "Fasce di colture estensive in campicoltura - cereali"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:566 a owl:Class ;
     schema:name "Mohn"@de,
@@ -2432,14 +2433,14 @@ cultivationtype:571 a owl:DeprecatedClass ;
         "Bande culturale extensive Légumineuses (féveroles, pois protéagineux, lupins et méteils du code 569)"@fr,
         "Fasce di colture estensive in campicoltura - leguminose a granelli (favette, piselli proteici, lupini e miscele con codice 569)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:572 a owl:Class ;
     schema:name "Nützlingsstreifen auf offener Ackerfläche"@de,
         "avec des céréales ou de la caméline, au moins 30 % de lentilles lors de la récolte (pour la production de grains)"@fr,
         "Strisce per organismi utili sulla superficie coltiva aperta"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:573 a owl:Class ;
     schema:name "Senf"@de,
@@ -2528,7 +2529,7 @@ cultivationtype:594 a owl:Class ;
         "Terres ouvertes donnant droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Superficie coltiva aperta, avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:595 a owl:Class ;
     schema:name "Nicht beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -2538,7 +2539,7 @@ cultivationtype:595 a owl:Class ;
         "Autres terres ouvertes ne donnant pas droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altra superficie coltiva aperta, non avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:597 a owl:Class ;
     schema:name "Beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -2575,7 +2576,7 @@ cultivationtype:611 a owl:Class ;
     "Les prairies exploitées de manière extensive ne sont pas fertilisées et sont fauchées tardivement, comme par exemple les prairies mi-sèches ou à brome. Elles représentent les herbages les plus riches en espèces de Suisse."@fr,
     "I prati sfruttati in modo estensivo non vengono concimati e vengono falciati tardi, come ad esempio i prati semi-aridi o a brometo. Rappresentano le praterie più ricche di specie della Svizzera."@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:612 a owl:Class ;
     schema:name "Wenig intensiv genutzte Wiesen (ohne Weiden)"@de,
@@ -2585,7 +2586,7 @@ cultivationtype:612 a owl:Class ;
     "Les prairies peu intensives sont des prairies légèrement fertilisées et fauchées tardivement, comme par exemple les prairies à fromental ou à avoine dorée."@fr,
     "I prati poco intensivi sono prati leggermente concimati e falciati tardi, come ad esempio i prati a fromental o ad avena bionda."@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity :22 .
+    :intensity intensity:Low .
 
 cultivationtype:613 a owl:Class ;
     schema:name "Übrige Dauerwiesen (ohne Weiden)"@de,
@@ -2604,7 +2605,7 @@ cultivationtype:617 a owl:Class ;
         "Pâturages extensifs"@fr,
         "Pascoli estensivi"@it ;
     rdfs:subClassOf cultivationtype:3 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:618 a owl:Class ;
     schema:name "Waldweiden (ohne bewaldete Fläche)"@de,
@@ -2665,21 +2666,21 @@ cultivationtype:693 a owl:Class ;
         "Surfaces de promotion de la biodiversité spécifiques à la région (pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (pascoli)"@it ;
     rdfs:subClassOf cultivationtype:3 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:694 a owl:Class ;
     schema:name "Regionsspezifische Biodiversitätsförderfläche (Grünflächen ohne Weiden)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère, sauf les pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite, senza pascoli)"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:695 a owl:DeprecatedClass ;
     schema:name "Regionsspezifische Biodiversitätsförderfläche (Grünfläche)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite)"@it ;
     rdfs:subClassOf cultivationtype:21 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:697 a owl:Class ;
     schema:name "Beitragsberechtigte übrige Dauergrünfläche"@de,
@@ -2852,7 +2853,7 @@ cultivationtype:735 a owl:Class ;
     schema:name "Reben (regionsspezifische Biodiversitätsförderflächen)"@de,
         "Vignes (surfaces de promotion de la biodiversité spécifiques à la ré-gion)"@fr,
         "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:750 a owl:Class ;
     schema:name "Übrige beitragsberechtigte Dauerkulturen"@de,
@@ -3007,7 +3008,7 @@ cultivationtype:858 a owl:Class ;
         "Haies, bosquets champêtres et berges boisées (avec la bande tampon) (Surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Siepi, boschetti campestri e rivieraschi (con fascia tampone) (Superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:9 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:895 a owl:Class ;
     schema:name "Dauergrünfläche übrige Flächen innerhalb der LN"@de,
@@ -3081,7 +3082,7 @@ cultivationtype:908 a owl:Class ;
         "Surfaces de promotion de la biodiversité spécifiques à la région"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione"@it ;
     rdfs:subClassOf cultivationtype:12 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:909 a owl:Class ;
     schema:name "Hausgärten"@de,
@@ -3137,14 +3138,14 @@ cultivationtype:927 a owl:Class ;
         "Autres arbres (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri alberi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:20 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:928 a owl:Class ;
     schema:name "Andere Elemente (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres éléments (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri elementi (superficie per la promozione della biodiversità specifica di una regione)"@it ;
     rdfs:subClassOf cultivationtype:20 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:929 a owl:Class ;
     schema:name "Andere Elemente (Landschaftsqualität)"@de,
@@ -3187,7 +3188,7 @@ cultivationtype:950 a owl:Class ;
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
     rdfs:subClassOf :Cultivation ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:951 a owl:Class ;
     schema:name "Getreide in weiter Reihe"@de,
@@ -3329,7 +3330,7 @@ cultivationtype:1021 a owl:Class ;
 cultivationtype:1023 a owl:Class ;
     schema:name "Nützlingsstreifen (DK)"@de ;
     rdfs:subClassOf cultivationtype:6 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:1024 a owl:Class ;
     schema:name "Hecken u. Feldgehölze mit Pufferstreifen (keine BFF)"@de ;
@@ -3416,7 +3417,7 @@ cultivationtype:1041 a owl:Class ;
 cultivationtype:1042 a owl:Class ;
     schema:name "Kunstwiese intensiv"@de, "Prairie artificielle intensive"@fr, "Prato artificiale intensivo"@it ;
     rdfs:subClassOf cultivationtype:601 ;
-    :intensity :24 .
+    :intensity intensity:Intensive .
 
 cultivationtype:1043 a owl:Class ;
     schema:name "Kohlrabi (geschützter Anbau)"@de, "Chou-rave (culture protégée)"@fr, "Cavolo rapa (coltura protetta)"@it ;
@@ -3616,7 +3617,7 @@ cultivationtype:1080 a owl:Class ;
     schema:name "Intensive Weiden und Mähweiden"@de ;
     schema:alternateName "Weide (Mäh-) intensiv"@de ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity :24 .
+    :intensity intensity:Intensive .
 
 cultivationtype:1081 a owl:Class ;
     schema:name "Stangenbohne (geschützter Anbau)"@de,
@@ -3651,7 +3652,7 @@ cultivationtype:1085 a owl:Class ;
         "Pascoli e pascoli da sfalcio medio-intensivi"@it ;
     schema:alternateName "Weide (Mäh-) mittelintensiv"@de ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity :23 .
+    :intensity intensity:Medium .
 
 cultivationtype:1086 a owl:Class ;
     schema:name "Schlüsselblume (ganze Pflanze)"@de,
@@ -3908,7 +3909,7 @@ cultivationtype:1126 a owl:Class ;
         "Pâturages peu intensifs"@fr,
         "Pascoli poco intensivi"@it ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity :22 .
+    :intensity intensity:Low .
 
 cultivationtype:1127 a owl:Class ;
     schema:name "Bundzwiebeln, Überwinterung"@de,
@@ -3945,14 +3946,14 @@ cultivationtype:1132 a owl:Class ;
         "Prairies de fauche de la région d'estivage, extensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, estensivi"@it ;
     rdfs:subClassOf cultivationtype:480 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:1133 a owl:Class ;
     schema:name "Heuwiesen Sömmerungsg., wenig intensiv"@de,
         "Prairies de fauche de la région d'estivage, peu intensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, poco intensivi"@it ;
     rdfs:subClassOf cultivationtype:480 ;
-    :intensity :22 .
+    :intensity intensity:Low .
 
 cultivationtype:1134 a owl:Class ;
     schema:name "Heuwiesen im Sömmerungsg., übrige"@de,
@@ -4082,21 +4083,21 @@ cultivationtype:1153 a owl:Class ;
         "Prairie naturelle moyennement intensive"@fr,
         "Prato naturale medio-intensivo"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity :23 .
+    :intensity intensity:Medium .
 
 cultivationtype:1154 a owl:Class ;
     schema:name "Kunstwiese mittelintensiv"@de,
         "Prairie artificielle moyennement intensive"@fr,
         "Prato artificiale medio-intensivo"@it ;
     rdfs:subClassOf cultivationtype:601 ;
-    :intensity :23 .
+    :intensity intensity:Medium .
 
 cultivationtype:1155 a owl:Class ;
     schema:name "Naturwiese intensiv"@de,
         "Prairie naturelle intensive"@fr,
         "Prato naturale intensivo"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity :24 .
+    :intensity intensity:Intensive .
 
 cultivationtype:1156 a owl:Class ;
     schema:name "Winterspinat, 1 Schnitt"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -2514,31 +2514,31 @@ cultivationtype:592 a owl:Class ;
     rdfs:subClassOf cultivationtype:493 .
 
 cultivationtype:594 a owl:Class ;
-    schema:name "Offene Ackerfläche, beitragsberechtigt"@de,
+    schema:name "Beitragsberechtigte offene Ackerfläche"@de,
         "Terres ouvertes donnant droit aux contributions"@fr,
         "Superficie coltiva aperta, avente diritto ai contributi"@it ;
-    schema:description "Offene Ackerfläche, beitragsberechtigt (regionsspezifische Biodiversitätsförderfläche)"@de,
+    schema:description "Beitragsberechtigte offene Ackerfläche (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Terres ouvertes donnant droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Superficie coltiva aperta, avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:595 a owl:Class ;
-    schema:name "Übrige offene Ackerfläche, nicht beitragsberechtigt"@de,
+    schema:name "Nicht beitragsberechtigte übrige offene Ackerfläche"@de,
         "Autres terres ouvertes ne donnant pas droit aux contributions"@fr,
         "Altra superficie coltiva aperta, non avente diritto ai contributi"@it ;
-    schema:description "Übrige offene Ackerfläche, nicht beitragsberechtigt (regionsspezifische Biodiversitätsförderfläche)"@de,
+    schema:description "Nicht beitragsberechtigte übrige offene Ackerfläche (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres terres ouvertes ne donnant pas droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altra superficie coltiva aperta, non avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:597 a owl:Class ;
-    schema:name "Übrige offene Ackerfläche, beitragsberechtigt"@de,
+    schema:name "Beitragsberechtigte übrige offene Ackerfläche"@de,
         "Autres terres ouvertes avec contributions"@fr,
         "Altra superficie coltiva aperta, con contributi"@it ;
     rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:598 a owl:Class ;
-    schema:name "Übrige offene Ackerfläche, nicht beitragsberechtigt"@de,
+    schema:name "Nicht beitragsberechtigte Übrige offene Ackerfläche"@de,
         "Autres terres ouvertes sans contributions"@fr,
         "Altra superficie coltiva aperta, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:1 .
@@ -2550,7 +2550,7 @@ cultivationtype:601 a owl:Class ;
     rdfs:subClassOf cultivationtype:1, cultivationtype:114 .
 
 cultivationtype:602 a owl:Class ;
-    schema:name "Übrige Kunstwiese, beitragsberechtigt"@de,
+    schema:name "Beitragsberechtigte übrige Kunstwiese"@de,
         "Autres prairies artificielles donnant droit aux contributions"@fr,
         "Altri prati artificiali avente diritto ai contributi"@it ;
     schema:description "Übrige Kunstwiese, beitragsberechtigt (z.B. Schweineweide, Geflügelweide)"@de,
@@ -2640,13 +2640,13 @@ cultivationtype:635 a owl:Class ;
     rdfs:subClassOf cultivationtype:2 .
 
 cultivationtype:650 a owl:Class ;
-    schema:name "Übrige Dauerwiesen, beitragsberechtigt aggregiert"@de,
+    schema:name "Beitragsberechtigte übrige Dauerwiesen"@de,
         "Autres prairies permanentes, avec contributions, agrégée"@fr,
         "Altra superficie inerbita, con contributi, aggregata"@it ;
     rdfs:subClassOf cultivationtype:2 .
 
 cultivationtype:660 a owl:Class ;
-    schema:name "Übrige Dauerweiden, beitragsberechtigt aggregiert"@de,
+    schema:name "Beitragsberechtigte übrige Dauerweiden"@de,
         "Autres pâturages permanentes, avec contributions, agrégée"@fr,
         "Altri pascoli perenni, con contributi, aggregata"@it ;
     rdfs:subClassOf cultivationtype:3 .
@@ -2670,13 +2670,13 @@ cultivationtype:695 a owl:DeprecatedClass ;
     rdfs:subClassOf cultivationtype:21 .
 
 cultivationtype:697 a owl:Class ;
-    schema:name "Übrige Grünfläche (Dauergrünfläche), beitragsberechtigt"@de,
+    schema:name "Beitragsberechtigte übrige Dauergrünfläche"@de,
         "Autres surfaces herbagères (surface herbagère permanente) avec contributions"@fr,
         "Altre superfici (permanentemente) inerbite, con contributi"@it ;
     rdfs:subClassOf cultivationtype:2 .
 
 cultivationtype:698 a owl:Class ;
-    schema:name "Übrige Grünfläche (Dauergrünflächen), nicht beitragsberechtigt"@de,
+    schema:name "Nicht beitragsberechtigte übrige Dauergrünflächen"@de,
         "Autres surfaces herbagères (surface herbagère permanente) sans contributions"@fr,
         "Altre superfici (permanentemente) inerbite, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:2 .
@@ -2848,19 +2848,19 @@ cultivationtype:750 a owl:Class ;
     rdfs:subClassOf cultivationtype:6 .
 
 cultivationtype:760 a owl:Class ;
-    schema:name "Dauerkulturen, nicht beitragsberechtigt, aggregiert"@de,
+    schema:name "Nicht beitragsberechtigte Dauerkulturen"@de,
         "Surfaces de cultures pérennes, sans contributions, agrégée"@fr,
         "Colture perenni, senza contributi, aggregata"@it ;
     rdfs:subClassOf cultivationtype:6 .
 
 cultivationtype:797 a owl:Class ;
-    schema:name "Übrige Flächen mit Dauerkulturen, beitragsberechtigt"@de,
+    schema:name "Dauergrünfläche übrige Flächen mit Dauerkulturen"@de,
         "Autres surfaces de cultures pérennes, avec contributions"@fr,
         "Altre superfici con colture perenni, con contributi"@it ;
     rdfs:subClassOf cultivationtype:750 .
 
 cultivationtype:798 a owl:Class ;
-    schema:name "Übrige Flächen mit Dauerkulturen, nicht beitragsberechtigt"@de,
+    schema:name "Nicht beitragsberechtigte übrige Flächen mit Dauerkulturen"@de,
         "Autres surfaces de cultures pérennes, sans contributions"@fr,
         "Altre superfici con colture perenni, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:6 .
@@ -2939,19 +2939,19 @@ cultivationtype:814 a owl:Class ;
     rdfs:subClassOf cultivationtype:470 .
 
 cultivationtype:830 a owl:Class ;
-    schema:name "Kulturen in ganzjährig geschütztem Anbau, beitragsberechtigt"@de,
+    schema:name "Beitragsberechtigte Kulturen in ganzjährig geschütztem Anbau"@de,
         "Cultures sous abri sans fondations permanentes, avec contributions"@fr,
         "Superfici con colture protette tutto l’anno, con contributi"@it ;
     rdfs:subClassOf cultivationtype:7 .
 
 cultivationtype:840 a owl:Class ;
-    schema:name "Kulturen in ganzjährig geschütztem Anbau, nicht beitragsberechtigt"@de,
+    schema:name "Nicht beitragsberechtigte Kulturen in ganzjährig geschütztem Anbau"@de,
         "Cultures sous abri sans fondations permanentes, sans contributions"@fr,
         "Superfici con colture protette tutto l’anno, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:7 .
 
 cultivationtype:847 a owl:Class ;
-    schema:name "Übrige Kulturen in geschütztem Anbau ohne festes Fundament, beitragsberechtigt"@de,
+    schema:name "Dauergrünfläche übrige Kulturen in geschütztem Anbau ohne festes Fundament"@de,
         "Autres cultures sous abri sans fondations permanentes, avec contributions"@fr,
         "Altre colture coltivate al coperto senza fondamenta fisse, con contributi"@it ;
     rdfs:subClassOf cultivationtype:830 .
@@ -2963,7 +2963,7 @@ cultivationtype:848 a owl:Class ;
     rdfs:subClassOf cultivationtype:830 .
 
 cultivationtype:849 a owl:Class ;
-    schema:name "Übrige Kulturen in geschütztem Anbau ohne festes Fundament, nicht beitragsberechtigt"@de,
+    schema:name "Nicht beitragsberechtigte übrige Kulturen in geschütztem Anbau ohne festes Fundament"@de,
         "Autres cultures sous abri sans fondations permanentes, sans contributions"@fr,
         "Altre colture coltivate al coperto senza fondamenta fisse, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:7 .
@@ -2996,19 +2996,19 @@ cultivationtype:858 a owl:Class ;
     rdfs:subClassOf cultivationtype:9 .
 
 cultivationtype:895 a owl:Class ;
-    schema:name "Übrige Flächen innerhalb der LN, beitragsberechtigt"@de,
+    schema:name "Dauergrünfläche übrige Flächen innerhalb der LN"@de,
         "Autres surfaces dans la SAU donnant droit aux contributions"@fr,
         "Altre superfici all'interno della SAU, aventi diritto ai contributi"@it ;
     rdfs:subClassOf cultivationtype:10 .
 
 cultivationtype:897 a owl:Class ;
-    schema:name "Übrige Flächen innerhalb der landwirtschaftlichen Nutzfläche, beitragsberechtigt"@de,
+    schema:name "Übrige beitragsberechtigte Flächen innerhalb der landwirtschaftlichen Nutzfläche"@de,
         "Autres surfaces dans la surface agricole utile, avec contributions"@fr,
         "Altre superfici all’interno della superficie agricola utilizzata, con contributi"@it ;
     rdfs:subClassOf cultivationtype:10 .
 
 cultivationtype:898 a owl:Class ;
-    schema:name "Übrige Flächen innerhalb der landwirtschaftlichen Nutzfläche, nicht beitragsberechtigt"@de,
+    schema:name "Nicht beitragsberechtigte übrige Flächen innerhalb der landwirtschaftlichen Nutzfläche"@de,
         "Autres surfaces dans la surface agricole utile, sans contributions"@fr,
         "Altre superfici all’interno della superficie agricola utilizzata, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:10 .

--- a/rdf/ontology/prefixes.ttl
+++ b/rdf/ontology/prefixes.ttl
@@ -3,6 +3,7 @@
 @prefix agis: <https://agriculture.ld.admin.ch/crops/agis/1/> .
 @prefix naebi: <https://agriculture.ld.admin.ch/crops/naebi/1> .
 @prefix cultivationtype: <https://agriculture.ld.admin.ch/crops/cultivationtype/> .
+@prefix taxon: <https://agriculture.ld.admin.ch/crops/taxon/> .
 
 @prefix cube: <https://cube.link/> .
 @prefix meta: <https://cube.link/meta/> .

--- a/rdf/ontology/prefixes.ttl
+++ b/rdf/ontology/prefixes.ttl
@@ -1,23 +1,27 @@
-@prefix : <https://agriculture.ld.admin.ch/crops/> .
-@prefix psm: <https://agriculture.ld.admin.ch/crops/psm/1/> .
-@prefix agis: <https://agriculture.ld.admin.ch/crops/agis/1/> .
-@prefix naebi: <https://agriculture.ld.admin.ch/crops/naebi/1> .
+# Project-specific namespaces/qnames
+@prefix :                <https://agriculture.ld.admin.ch/crops/> .
+@prefix psm:             <https://agriculture.ld.admin.ch/crops/psm/1/> .
+@prefix agis:            <https://agriculture.ld.admin.ch/crops/agis/1/> .
+@prefix naebi:           <https://agriculture.ld.admin.ch/crops/naebi/1> .
 @prefix cultivationtype: <https://agriculture.ld.admin.ch/crops/cultivationtype/> .
-@prefix taxon: <https://agriculture.ld.admin.ch/crops/taxon/> .
+@prefix taxon:           <https://agriculture.ld.admin.ch/crops/taxon/> .
+@prefix intensity:       <https://agriculture.ld.admin.ch/crops/intensity/> .
 
-@prefix cube: <https://cube.link/> .
-@prefix meta: <https://cube.link/meta/> .
+# LINDAS-specific namespaces/qnames
+@prefix cube:            <https://cube.link/> .
+@prefix meta:            <https://cube.link/meta/> .
+@prefix theme:           <https://register.ld.admin.ch/opendataswiss/category/> .
+@prefix blw:             <https://register.ld.admin.ch/opendataswiss/org/bundesamt-fur-landwirtschaft-blw> .
 
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix qudt: <http://qudt.org/schema/qudt/> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix schema: <http://schema.org/> .
-@prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
-@prefix void: <http://rdfs.org/ns/void#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix theme: <https://register.ld.admin.ch/opendataswiss/category/> .
-@prefix blw: <https://register.ld.admin.ch/opendataswiss/org/bundesamt-fur-landwirtschaft-blw> .
-@prefix frequency: <http://publications.europe.eu/resource/authority/frequency> .
-@prefix status: <https://ld.admin.ch/vocabulary/CreativeWorkStatus/> .
+# Globally used namespaces/qnames
+@prefix dcat:            <http://www.w3.org/ns/dcat#> .
+@prefix dcterms:         <http://purl.org/dc/terms/> .
+@prefix qudt:            <http://qudt.org/schema/qudt/> .
+@prefix rdf:             <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema:          <http://schema.org/> .
+@prefix sh:              <http://www.w3.org/ns/shacl#> .
+@prefix vcard:           <http://www.w3.org/2006/vcard/ns#> .
+@prefix void:            <http://rdfs.org/ns/void#> .
+@prefix xsd:             <http://www.w3.org/2001/XMLSchema#> .
+@prefix frequency:       <http://publications.europe.eu/resource/authority/frequency> .
+@prefix status:          <https://ld.admin.ch/vocabulary/CreativeWorkStatus/> .

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -868,7 +868,8 @@ cultivationtype:1132 a owl:Class ;
     rdfs:label "Heuwiesen Sömmerungsg., extensive"@de,
         "Prairies de fauche de la région d'estivage, extensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, estensivi"@it ;
-    rdfs:subClassOf cultivationtype:480 .
+    rdfs:subClassOf cultivationtype:480 ;
+    :intensity :21 .
 
 cultivationtype:1133 a owl:Class ;
     rdfs:label "Heuwiesen Sömmerungsg., wenig intensiv"@de,
@@ -1222,18 +1223,6 @@ cultivationtype:1195 a owl:Class ;
         "Erbe aromatiche, perenni, piccole"@it ;
     rdfs:subClassOf cultivationtype:1287 .
 
-cultivationtype:1198 a owl:Class ;
-    rdfs:label "Vom Betrieb weggeführtes Rübenblatt"@de,
-        "Beet leaves exported from farm"@en,
-        "Feuilles de betteraves exportées de l'exploitation"@fr,
-        "Foglie di barbabietola esportate dall'azienda"@it .
-
-cultivationtype:1199 a owl:Class ;
-    rdfs:label "Kleine Anlagen (<20 a) mit versch. Dauerkulturen"@de,
-        "Small installations (<20 a) with various permanent crops"@en,
-        "Petites installations (<20 a) avec diverses cultures permanentes"@fr,
-        "Piccoli impianti (<20 a) con diverse colture permanenti"@it .
-
 cultivationtype:12 a owl:Class ;
     rdfs:label "Flächen ausserhalb der landwirtschaftlichen Nutzfläche"@de,
         "Surfaces en dehors de la surface agricole utile"@fr,
@@ -1253,30 +1242,12 @@ cultivationtype:1200 a owl:Class ;
         "Cavolo rapa da trasformazione"@it ;
     rdfs:subClassOf cultivationtype:86 .
 
-cultivationtype:1202 a owl:Class ;
-    rdfs:label "Kleesamenproduktion"@de,
-        "Clover seed production"@en,
-        "Production de semences de trèfle"@fr,
-        "Produzione di sementi di trifoglio"@it .
-
-cultivationtype:1203 a owl:Class ;
-    rdfs:label "Gründüngung Leguminosen (Freilandgemüse)"@de,
-        "Green manure legumes (open field vegetables)"@en,
-        "Engrais vert légumineuses (légumes de plein champ)"@fr,
-        "Sovescio leguminose (ortaggi in pieno campo)"@it .
-
 cultivationtype:1204 a owl:Class ;
     rdfs:label "Nussbäume, 0.01 ha/Baum"@de,
         "Walnut trees, 0.01 ha/tree"@en,
         "Noyers, 0.01 ha/arbre"@fr,
         "Noci, 0.01 ha/albero"@it ;
     rdfs:subClassOf cultivationtype:922 .
-
-cultivationtype:1205 a owl:Class ;
-    rdfs:label "betriebseigenes verfütt. Rübenblatt"@de,
-        "Home-grown fed beet leaves"@en,
-        "Feuilles de betteraves fourragères de l'exploitation"@fr,
-        "Foglie di barbabietola foraggera dell'azienda"@it .
 
 cultivationtype:1206 a owl:Class ;
     rdfs:label "Einjährige Erdbeeren"@de ;
@@ -1379,12 +1350,6 @@ cultivationtype:122 a owl:Class ;
     rdfs:subClassOf cultivationtype:118,
         cultivationtype:72 .
 
-cultivationtype:1220 a owl:Class ;
-    rdfs:label "Vom Betrieb weggeführtes Stroh"@de,
-        "Straw exported from farm"@en,
-        "Paille exportée de l'exploitation"@fr,
-        "Paglia esportata dall'azienda"@it .
-
 cultivationtype:1221 a owl:Class ;
     rdfs:label "Erdbeeren 1-jährig, 2.0 kg/m2"@de,
         "Strawberries 1-year, 2.0 kg/m2"@en,
@@ -1398,12 +1363,6 @@ cultivationtype:1222 a owl:Class ;
         "Fraises annuelles, 4.0 kg/m2"@fr,
         "Fragole annuali, 4.0 kg/m2"@it ;
     rdfs:subClassOf cultivationtype:1206 .
-
-cultivationtype:1223 a owl:Class ;
-    rdfs:label "Nicht aufgef. Ackerkult., Nicht-Leg.,Mischungen Leg.+Nicht-Leg"@de,
-        "Unlisted arable crops, non-legumes, mixtures legumes+non-legumes"@en,
-        "Cultures des champs non listées, non-lég., mélanges lég.+non-lég."@fr,
-        "Colture campestri non elencate, non leguminose, miscele leguminose+non leguminose"@it .
 
 cultivationtype:1224 a owl:Class ;
     rdfs:label "Winterspinat, 1 Schnitt"@de,
@@ -1685,18 +1644,6 @@ cultivationtype:1273 a owl:Class ;
         "Uva spina, 2.5 kg/m2"@it ;
     rdfs:subClassOf cultivationtype:298 .
 
-cultivationtype:1275 a owl:Class ;
-    rdfs:label "Gründüngung (Leguminosen)"@de,
-        "Green manure (legumes)"@en,
-        "Engrais vert (légumineuses)"@fr,
-        "Sovescio (leguminose)"@it .
-
-cultivationtype:1277 a owl:Class ;
-    rdfs:label "Gründüngung (Nichtleguminosen)"@de,
-        "Green manure (non-legumes)"@en,
-        "Engrais vert (non-légumineuses)"@fr,
-        "Sovescio (non leguminose)"@it .
-
 cultivationtype:1278 a owl:Class ;
     rdfs:label "Stachelbeeren, 1.7 kg/m2"@de,
         "Gooseberries, 1.7 kg/m2"@en,
@@ -1731,12 +1678,6 @@ cultivationtype:1284 a owl:Class ;
         "Arbres fruitiers à haute tige, 0.01ha/arbre"@fr,
         "Alberi da frutto ad alto fusto, 0.01ha/albero"@it ;
     rdfs:subClassOf cultivationtype:921 .
-
-cultivationtype:1285 a owl:Class ;
-    rdfs:label "Hecken und Feldgehölz mit Krautsaum"@de,
-        "Hedges and field copses with herbaceous margin"@en,
-        "Haies et bosquets champêtres avec ourlet herbacé"@fr,
-        "Siepi e boschetti campestri con margine erbaceo"@it .
 
 cultivationtype:1286 a owl:Class ;
     rdfs:label "Einjährige Kräuter"@de ;
@@ -1817,7 +1758,7 @@ cultivationtype:14 a owl:Class ;
     rdfs:label "Getreide"@de,
         "Céréales"@fr,
         "Cereali"@it ;
-    rdfs:comment "Der Anbau von verschiedenen Getreidearten wie Weizen, Gerste, Roggenfer oder Dinkel. Das Hauptziel ist die Gewinnung der Körner zur Nutzung als Lebens- oder Futtermittel."@de ;
+    rdfs:comment "Der Anbau von verschiedenen Getreidearten wie Weizen, Gerste, Roggen, Hafer oder Dinkel. Das Hauptziel ist die Gewinnung der Körner zur Nutzung als Lebens- oder Futtermittel."@de ;
     rdfs:subClassOf cultivationtype:1032 .
 
 cultivationtype:140 a owl:Class ;
@@ -3523,7 +3464,8 @@ cultivationtype:555 a owl:Class ;
     rdfs:label "Ackerschonstreifen"@de,
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:556 a owl:Class ;
     rdfs:label "Buntbrache"@de,
@@ -3685,31 +3627,31 @@ cultivationtype:592 a owl:Class ;
     rdfs:subClassOf cultivationtype:493 .
 
 cultivationtype:594 a owl:Class ;
-    rdfs:label "Offene Ackerfläche, beitragsberechtigt"@de,
+    rdfs:label "Beitragsberechtigte offene Ackerfläche"@de,
         "Terres ouvertes donnant droit aux contributions"@fr,
         "Superficie coltiva aperta, avente diritto ai contributi"@it ;
-    rdfs:comment "Offene Ackerfläche, beitragsberechtigt (regionsspezifische Biodiversitätsförderfläche)"@de,
+    rdfs:comment "Beitragsberechtigte offene Ackerfläche (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Terres ouvertes donnant droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Superficie coltiva aperta, avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:595 a owl:Class ;
-    rdfs:label "Übrige offene Ackerfläche, nicht beitragsberechtigt"@de,
+    rdfs:label "Nicht beitragsberechtigte übrige offene Ackerfläche"@de,
         "Autres terres ouvertes ne donnant pas droit aux contributions"@fr,
         "Altra superficie coltiva aperta, non avente diritto ai contributi"@it ;
-    rdfs:comment "Übrige offene Ackerfläche, nicht beitragsberechtigt (regionsspezifische Biodiversitätsförderfläche)"@de,
+    rdfs:comment "Nicht beitragsberechtigte übrige offene Ackerfläche (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres terres ouvertes ne donnant pas droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altra superficie coltiva aperta, non avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:597 a owl:Class ;
-    rdfs:label "Übrige offene Ackerfläche, beitragsberechtigt"@de,
+    rdfs:label "Beitragsberechtigte übrige offene Ackerfläche"@de,
         "Autres terres ouvertes avec contributions"@fr,
         "Altra superficie coltiva aperta, con contributi"@it ;
     rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:598 a owl:Class ;
-    rdfs:label "Übrige offene Ackerfläche, nicht beitragsberechtigt"@de,
+    rdfs:label "Nicht beitragsberechtigte Übrige offene Ackerfläche"@de,
         "Autres terres ouvertes sans contributions"@fr,
         "Altra superficie coltiva aperta, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:1 .
@@ -3734,7 +3676,7 @@ cultivationtype:601 a owl:Class ;
         cultivationtype:114 .
 
 cultivationtype:602 a owl:Class ;
-    rdfs:label "Übrige Kunstwiese, beitragsberechtigt"@de,
+    rdfs:label "Beitragsberechtigte übrige Kunstwiese"@de,
         "Autres prairies artificielles donnant droit aux contributions"@fr,
         "Altri prati artificiali avente diritto ai contributi"@it ;
     rdfs:comment "Übrige Kunstwiese, beitragsberechtigt (z.B. Schweineweide, Geflügelweide)"@de,
@@ -3827,7 +3769,7 @@ cultivationtype:65 a owl:Class ;
         cultivationtype:145 .
 
 cultivationtype:650 a owl:Class ;
-    rdfs:label "Übrige Dauerwiesen, beitragsberechtigt aggregiert"@de,
+    rdfs:label "Beitragsberechtigte übrige Dauerwiesen"@de,
         "Autres prairies permanentes, avec contributions, agrégée"@fr,
         "Altra superficie inerbita, con contributi, aggregata"@it ;
     rdfs:subClassOf cultivationtype:2 .
@@ -3839,7 +3781,7 @@ cultivationtype:66 a owl:Class ;
     rdfs:subClassOf cultivationtype:48 .
 
 cultivationtype:660 a owl:Class ;
-    rdfs:label "Übrige Dauerweiden, beitragsberechtigt aggregiert"@de,
+    rdfs:label "Beitragsberechtigte übrige Dauerweiden"@de,
         "Autres pâturages permanentes, avec contributions, agrégée"@fr,
         "Altri pascoli perenni, con contributi, aggregata"@it ;
     rdfs:subClassOf cultivationtype:3 .
@@ -3879,13 +3821,13 @@ cultivationtype:694 a owl:Class ;
     rdfs:subClassOf cultivationtype:2 .
 
 cultivationtype:697 a owl:Class ;
-    rdfs:label "Übrige Grünfläche (Dauergrünfläche), beitragsberechtigt"@de,
+    rdfs:label "Beitragsberechtigte übrige Dauergrünfläche"@de,
         "Autres surfaces herbagères (surface herbagère permanente) avec contributions"@fr,
         "Altre superfici (permanentemente) inerbite, con contributi"@it ;
     rdfs:subClassOf cultivationtype:2 .
 
 cultivationtype:698 a owl:Class ;
-    rdfs:label "Übrige Grünfläche (Dauergrünflächen), nicht beitragsberechtigt"@de,
+    rdfs:label "Nicht beitragsberechtigte übrige Dauergrünflächen"@de,
         "Autres surfaces herbagères (surface herbagère permanente) sans contributions"@fr,
         "Altre superfici (permanentemente) inerbite, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:2 .
@@ -4084,7 +4026,7 @@ cultivationtype:76 a owl:Class ;
     rdfs:subClassOf cultivationtype:321 .
 
 cultivationtype:760 a owl:Class ;
-    rdfs:label "Dauerkulturen, nicht beitragsberechtigt, aggregiert"@de,
+    rdfs:label "Nicht beitragsberechtigte Dauerkulturen"@de,
         "Surfaces de cultures pérennes, sans contributions, agrégée"@fr,
         "Colture perenni, senza contributi, aggregata"@it ;
     rdfs:subClassOf cultivationtype:6 .
@@ -4103,13 +4045,13 @@ cultivationtype:79 a owl:Class ;
     rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:797 a owl:Class ;
-    rdfs:label "Übrige Flächen mit Dauerkulturen, beitragsberechtigt"@de,
+    rdfs:label "Dauergrünfläche übrige Flächen mit Dauerkulturen"@de,
         "Autres surfaces de cultures pérennes, avec contributions"@fr,
         "Altre superfici con colture perenni, con contributi"@it ;
     rdfs:subClassOf cultivationtype:750 .
 
 cultivationtype:798 a owl:Class ;
-    rdfs:label "Übrige Flächen mit Dauerkulturen, nicht beitragsberechtigt"@de,
+    rdfs:label "Nicht beitragsberechtigte übrige Flächen mit Dauerkulturen"@de,
         "Autres surfaces de cultures pérennes, sans contributions"@fr,
         "Altre superfici con colture perenni, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:6 .
@@ -4213,7 +4155,7 @@ cultivationtype:83 a owl:Class ;
     rdfs:subClassOf cultivationtype:35 .
 
 cultivationtype:830 a owl:Class ;
-    rdfs:label "Kulturen in ganzjährig geschütztem Anbau, beitragsberechtigt"@de,
+    rdfs:label "Beitragsberechtigte Kulturen in ganzjährig geschütztem Anbau"@de,
         "Cultures sous abri sans fondations permanentes, avec contributions"@fr,
         "Superfici con colture protette tutto l’anno, con contributi"@it ;
     rdfs:subClassOf cultivationtype:7 .
@@ -4225,13 +4167,13 @@ cultivationtype:84 a owl:Class ;
     rdfs:subClassOf cultivationtype:115 .
 
 cultivationtype:840 a owl:Class ;
-    rdfs:label "Kulturen in ganzjährig geschütztem Anbau, nicht beitragsberechtigt"@de,
+    rdfs:label "Nicht beitragsberechtigte Kulturen in ganzjährig geschütztem Anbau"@de,
         "Cultures sous abri sans fondations permanentes, sans contributions"@fr,
         "Superfici con colture protette tutto l’anno, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:7 .
 
 cultivationtype:847 a owl:Class ;
-    rdfs:label "Übrige Kulturen in geschütztem Anbau ohne festes Fundament, beitragsberechtigt"@de,
+    rdfs:label "Dauergrünfläche übrige Kulturen in geschütztem Anbau ohne festes Fundament"@de,
         "Autres cultures sous abri sans fondations permanentes, avec contributions"@fr,
         "Altre colture coltivate al coperto senza fondamenta fisse, con contributi"@it ;
     rdfs:subClassOf cultivationtype:830 .
@@ -4243,7 +4185,7 @@ cultivationtype:848 a owl:Class ;
     rdfs:subClassOf cultivationtype:830 .
 
 cultivationtype:849 a owl:Class ;
-    rdfs:label "Übrige Kulturen in geschütztem Anbau ohne festes Fundament, nicht beitragsberechtigt"@de,
+    rdfs:label "Nicht beitragsberechtigte übrige Kulturen in geschütztem Anbau ohne festes Fundament"@de,
         "Autres cultures sous abri sans fondations permanentes, sans contributions"@fr,
         "Altre colture coltivate al coperto senza fondamenta fisse, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:7 .
@@ -4307,19 +4249,19 @@ cultivationtype:89 a owl:Class ;
     rdfs:subClassOf cultivationtype:277 .
 
 cultivationtype:895 a owl:Class ;
-    rdfs:label "Übrige Flächen innerhalb der LN, beitragsberechtigt"@de,
+    rdfs:label "Dauergrünfläche übrige Flächen innerhalb der LN"@de,
         "Autres surfaces dans la SAU donnant droit aux contributions"@fr,
         "Altre superfici all'interno della SAU, aventi diritto ai contributi"@it ;
     rdfs:subClassOf cultivationtype:10 .
 
 cultivationtype:897 a owl:Class ;
-    rdfs:label "Übrige Flächen innerhalb der landwirtschaftlichen Nutzfläche, beitragsberechtigt"@de,
+    rdfs:label "Übrige beitragsberechtigte Flächen innerhalb der landwirtschaftlichen Nutzfläche"@de,
         "Autres surfaces dans la surface agricole utile, avec contributions"@fr,
         "Altre superfici all’interno della superficie agricola utilizzata, con contributi"@it ;
     rdfs:subClassOf cultivationtype:10 .
 
 cultivationtype:898 a owl:Class ;
-    rdfs:label "Übrige Flächen innerhalb der landwirtschaftlichen Nutzfläche, nicht beitragsberechtigt"@de,
+    rdfs:label "Nicht beitragsberechtigte übrige Flächen innerhalb der landwirtschaftlichen Nutzfläche"@de,
         "Autres surfaces dans la surface agricole utile, sans contributions"@fr,
         "Altre superfici all’interno della superficie agricola utilizzata, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:10 .
@@ -4523,7 +4465,8 @@ cultivationtype:950 a owl:Class ;
     rdfs:label "Ackerschonstreifen"@de,
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
-    rdfs:subClassOf :Cultivation .
+    rdfs:subClassOf :Cultivation ;
+    :intensity :21 .
 
 cultivationtype:951 a owl:Class ;
     rdfs:label "Getreide in weiter Reihe"@de,
@@ -4606,13 +4549,15 @@ cultivationtype:564 a owl:DeprecatedClass ;
     rdfs:label "Ackerschonstreifen Ölsaaten (Raps, Sonnenblumen, Lein)"@de,
         "Bande culturale extensive Oléagineux (colza, tournesols, lin)"@fr,
         "Fasce di colture estensive in campicoltura - semi oleosi (colza, girasole, lino)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:565 a owl:DeprecatedClass ;
     rdfs:label "Ackerschonstreifen Getreide"@de,
         "Bande culturale extensive céréales"@fr,
         "Fasce di colture estensive in campicoltura - cereali"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:571 a owl:DeprecatedClass ;
     rdfs:label "Ackerschonstreifen Körnerleguminosen"@de,
@@ -4621,7 +4566,8 @@ cultivationtype:571 a owl:DeprecatedClass ;
     rdfs:comment "Ackerschonstreifen Körnerleguminosen (Ackerbohnen, Eiweisserbsen, Lupinen und Mischungen mit Code 569)"@de,
         "Bande culturale extensive Légumineuses (féveroles, pois protéagineux, lupins et méteils du code 569)"@fr,
         "Fasce di colture estensive in campicoltura - leguminose a granelli (favette, piselli proteici, lupini e miscele con codice 569)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:619 a owl:DeprecatedClass ;
     rdfs:label "Weiden für Schweine, nicht anrechenbar für die Berechnung der RGVE"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -1,6 +1,7 @@
 @prefix : <https://agriculture.ld.admin.ch/crops/> .
 @prefix cultivationtype: <https://agriculture.ld.admin.ch/crops/cultivationtype/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix intensity: <https://agriculture.ld.admin.ch/crops/intensity/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -157,7 +158,7 @@ cultivationtype:1021 a owl:Class ;
 cultivationtype:1023 a owl:Class ;
     rdfs:label "Nützlingsstreifen (DK)"@de ;
     rdfs:subClassOf cultivationtype:6 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:1024 a owl:Class ;
     rdfs:label "Hecken u. Feldgehölze mit Pufferstreifen (keine BFF)"@de ;
@@ -262,7 +263,7 @@ cultivationtype:1042 a owl:Class ;
         "Prairie artificielle intensive"@fr,
         "Prato artificiale intensivo"@it ;
     rdfs:subClassOf cultivationtype:601 ;
-    :intensity :24 .
+    :intensity intensity:Intensive .
 
 cultivationtype:1043 a owl:Class ;
     rdfs:label "Kohlrabi (geschützter Anbau)"@de,
@@ -527,7 +528,7 @@ cultivationtype:1080 a owl:Class ;
     rdfs:label "Intensive Weiden und Mähweiden"@de ;
     schema:alternateName "Weide (Mäh-) intensiv"@de ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity :24 .
+    :intensity intensity:Intensive .
 
 cultivationtype:1081 a owl:Class ;
     rdfs:label "Stangenbohne (geschützter Anbau)"@de,
@@ -559,7 +560,7 @@ cultivationtype:1085 a owl:Class ;
         "Pascoli e pascoli da sfalcio medio-intensivi"@it ;
     schema:alternateName "Weide (Mäh-) mittelintensiv"@de ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity :23 .
+    :intensity intensity:Medium .
 
 cultivationtype:1086 a owl:Class ;
     rdfs:label "Schlüsselblume (ganze Pflanze)"@de,
@@ -830,7 +831,7 @@ cultivationtype:1126 a owl:Class ;
         "Pâturages peu intensifs"@fr,
         "Pascoli poco intensivi"@it ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity :22 .
+    :intensity intensity:Low .
 
 cultivationtype:1127 a owl:Class ;
     rdfs:label "Bundzwiebeln, Überwinterung"@de,
@@ -874,14 +875,14 @@ cultivationtype:1132 a owl:Class ;
         "Prairies de fauche de la région d'estivage, extensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, estensivi"@it ;
     rdfs:subClassOf cultivationtype:480 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:1133 a owl:Class ;
     rdfs:label "Heuwiesen Sömmerungsg., wenig intensiv"@de,
         "Prairies de fauche de la région d'estivage, peu intensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, poco intensivi"@it ;
     rdfs:subClassOf cultivationtype:480 ;
-    :intensity :22 .
+    :intensity intensity:Low .
 
 cultivationtype:1134 a owl:Class ;
     rdfs:label "Heuwiesen im Sömmerungsg., übrige"@de,
@@ -1020,21 +1021,21 @@ cultivationtype:1153 a owl:Class ;
         "Prairie naturelle moyennement intensive"@fr,
         "Prato naturale medio-intensivo"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity :23 .
+    :intensity intensity:Medium .
 
 cultivationtype:1154 a owl:Class ;
     rdfs:label "Kunstwiese mittelintensiv"@de,
         "Prairie artificielle moyennement intensive"@fr,
         "Prato artificiale medio-intensivo"@it ;
     rdfs:subClassOf cultivationtype:601 ;
-    :intensity :23 .
+    :intensity intensity:Medium .
 
 cultivationtype:1155 a owl:Class ;
     rdfs:label "Naturwiese intensiv"@de,
         "Prairie naturelle intensive"@fr,
         "Prato naturale intensivo"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity :24 .
+    :intensity intensity:Intensive .
 
 cultivationtype:1156 a owl:Class ;
     rdfs:label "Winterspinat, 1 Schnitt"@de,
@@ -3474,14 +3475,14 @@ cultivationtype:555 a owl:Class ;
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:556 a owl:Class ;
     rdfs:label "Buntbrache"@de,
         "Jachère florale"@fr,
         "Maggese fioriti"@it ;
     rdfs:subClassOf cultivationtype:77 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:557 a owl:Class ;
     rdfs:label "Rotationsbrache"@de,
@@ -3489,7 +3490,7 @@ cultivationtype:557 a owl:Class ;
         "Jachère tournante"@fr,
         "Maggese da rotazione"@it ;
     rdfs:subClassOf cultivationtype:77 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:559 a owl:Class ;
     rdfs:label "Saum auf Ackerflächen"@de,
@@ -3551,7 +3552,7 @@ cultivationtype:572 a owl:Class ;
         "avec des céréales ou de la caméline, au moins 30 % de lentilles lors de la récolte (pour la production de grains)"@fr,
         "Strisce per organismi utili sulla superficie coltiva aperta"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:573 a owl:Class ;
     rdfs:label "Senf"@de,
@@ -3646,7 +3647,7 @@ cultivationtype:594 a owl:Class ;
         "Terres ouvertes donnant droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Superficie coltiva aperta, avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:595 a owl:Class ;
     rdfs:label "Nicht beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -3656,7 +3657,7 @@ cultivationtype:595 a owl:Class ;
         "Autres terres ouvertes ne donnant pas droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altra superficie coltiva aperta, non avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:597 a owl:Class ;
     rdfs:label "Beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -3707,7 +3708,7 @@ cultivationtype:611 a owl:Class ;
         "Les prairies exploitées de manière extensive ne sont pas fertilisées et sont fauchées tardivement, comme par exemple les prairies mi-sèches ou à brome. Elles représentent les herbages les plus riches en espèces de Suisse."@fr,
         "I prati sfruttati in modo estensivo non vengono concimati e vengono falciati tardi, come ad esempio i prati semi-aridi o a brometo. Rappresentano le praterie più ricche di specie della Svizzera."@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:612 a owl:Class ;
     rdfs:label "Wenig intensiv genutzte Wiesen (ohne Weiden)"@de,
@@ -3717,7 +3718,7 @@ cultivationtype:612 a owl:Class ;
         "Les prairies peu intensives sont des prairies légèrement fertilisées et fauchées tardivement, comme par exemple les prairies à fromental ou à avoine dorée."@fr,
         "I prati poco intensivi sono prati leggermente concimati e falciati tardi, come ad esempio i prati a fromental o ad avena bionda."@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity :22 .
+    :intensity intensity:Low .
 
 cultivationtype:613 a owl:Class ;
     rdfs:label "Übrige Dauerwiesen (ohne Weiden)"@de,
@@ -3736,7 +3737,7 @@ cultivationtype:617 a owl:Class ;
         "Pâturages extensifs"@fr,
         "Pascoli estensivi"@it ;
     rdfs:subClassOf cultivationtype:3 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:618 a owl:Class ;
     rdfs:label "Waldweiden (ohne bewaldete Fläche)"@de,
@@ -3827,14 +3828,14 @@ cultivationtype:693 a owl:Class ;
         "Surfaces de promotion de la biodiversité spécifiques à la région (pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (pascoli)"@it ;
     rdfs:subClassOf cultivationtype:3 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:694 a owl:Class ;
     rdfs:label "Regionsspezifische Biodiversitätsförderfläche (Grünflächen ohne Weiden)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère, sauf les pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite, senza pascoli)"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:697 a owl:Class ;
     rdfs:label "Beitragsberechtigte übrige Dauergrünfläche"@de,
@@ -4014,7 +4015,7 @@ cultivationtype:735 a owl:Class ;
     rdfs:label "Reben (regionsspezifische Biodiversitätsförderflächen)"@de,
         "Vignes (surfaces de promotion de la biodiversité spécifiques à la ré-gion)"@fr,
         "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:75 a owl:Class ;
     rdfs:label "Portulak"@de,
@@ -4239,7 +4240,7 @@ cultivationtype:858 a owl:Class ;
         "Haies, bosquets champêtres et berges boisées (avec la bande tampon) (Surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Siepi, boschetti campestri e rivieraschi (con fascia tampone) (Superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:9 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:86 a owl:Class ;
     rdfs:label "Kohlrabi"@de,
@@ -4350,7 +4351,7 @@ cultivationtype:908 a owl:Class ;
         "Surfaces de promotion de la biodiversité spécifiques à la région"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione"@it ;
     rdfs:subClassOf cultivationtype:12 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:909 a owl:Class ;
     rdfs:label "Hausgärten"@de,
@@ -4418,14 +4419,14 @@ cultivationtype:927 a owl:Class ;
         "Autres arbres (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri alberi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:20 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:928 a owl:Class ;
     rdfs:label "Andere Elemente (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres éléments (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri elementi (superficie per la promozione della biodiversità specifica di una regione)"@it ;
     rdfs:subClassOf cultivationtype:20 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:929 a owl:Class ;
     rdfs:label "Andere Elemente (Landschaftsqualität)"@de,
@@ -4487,7 +4488,7 @@ cultivationtype:950 a owl:Class ;
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
     rdfs:subClassOf :Cultivation ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:951 a owl:Class ;
     rdfs:label "Getreide in weiter Reihe"@de,
@@ -4571,14 +4572,14 @@ cultivationtype:564 a owl:DeprecatedClass ;
         "Bande culturale extensive Oléagineux (colza, tournesols, lin)"@fr,
         "Fasce di colture estensive in campicoltura - semi oleosi (colza, girasole, lino)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:565 a owl:DeprecatedClass ;
     rdfs:label "Ackerschonstreifen Getreide"@de,
         "Bande culturale extensive céréales"@fr,
         "Fasce di colture estensive in campicoltura - cereali"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:571 a owl:DeprecatedClass ;
     rdfs:label "Ackerschonstreifen Körnerleguminosen"@de,
@@ -4588,7 +4589,7 @@ cultivationtype:571 a owl:DeprecatedClass ;
         "Bande culturale extensive Légumineuses (féveroles, pois protéagineux, lupins et méteils du code 569)"@fr,
         "Fasce di colture estensive in campicoltura - leguminose a granelli (favette, piselli proteici, lupini e miscele con codice 569)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:619 a owl:DeprecatedClass ;
     rdfs:label "Weiden für Schweine, nicht anrechenbar für die Berechnung der RGVE"@de,
@@ -4607,7 +4608,7 @@ cultivationtype:695 a owl:DeprecatedClass ;
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite)"@it ;
     rdfs:subClassOf cultivationtype:21 ;
-    :intensity :21 .
+    :intensity intensity:Extensive .
 
 cultivationtype:716 a owl:DeprecatedClass ;
     rdfs:label "Gepflegte Selven (Kastanien-/Nussbäume)"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -260,7 +260,8 @@ cultivationtype:1042 a owl:Class ;
     rdfs:label "Kunstwiese intensiv"@de,
         "Prairie artificielle intensive"@fr,
         "Prato artificiale intensivo"@it ;
-    rdfs:subClassOf cultivationtype:601 .
+    rdfs:subClassOf cultivationtype:601 ;
+    :intensity :24 .
 
 cultivationtype:1043 a owl:Class ;
     rdfs:label "Kohlrabi (geschützter Anbau)"@de,
@@ -524,7 +525,8 @@ cultivationtype:108 a owl:Class ;
 cultivationtype:1080 a owl:Class ;
     rdfs:label "Intensive Weiden und Mähweiden"@de ;
     schema:alternateName "Weide (Mäh-) intensiv"@de ;
-    rdfs:subClassOf cultivationtype:616 .
+    rdfs:subClassOf cultivationtype:616 ;
+    :intensity :24 .
 
 cultivationtype:1081 a owl:Class ;
     rdfs:label "Stangenbohne (geschützter Anbau)"@de,
@@ -555,7 +557,8 @@ cultivationtype:1085 a owl:Class ;
         "Pâturages et pâturages de fauche moyennement intensifs"@fr,
         "Pascoli e pascoli da sfalcio medio-intensivi"@it ;
     schema:alternateName "Weide (Mäh-) mittelintensiv"@de ;
-    rdfs:subClassOf cultivationtype:616 .
+    rdfs:subClassOf cultivationtype:616 ;
+    :intensity :23 .
 
 cultivationtype:1086 a owl:Class ;
     rdfs:label "Schlüsselblume (ganze Pflanze)"@de,
@@ -825,7 +828,8 @@ cultivationtype:1126 a owl:Class ;
     rdfs:label "Wenig intensiv genutzte Weiden"@de,
         "Pâturages peu intensifs"@fr,
         "Pascoli poco intensivi"@it ;
-    rdfs:subClassOf cultivationtype:616 .
+    rdfs:subClassOf cultivationtype:616 ;
+    :intensity :22 .
 
 cultivationtype:1127 a owl:Class ;
     rdfs:label "Bundzwiebeln, Überwinterung"@de,
@@ -875,7 +879,8 @@ cultivationtype:1133 a owl:Class ;
     rdfs:label "Heuwiesen Sömmerungsg., wenig intensiv"@de,
         "Prairies de fauche de la région d'estivage, peu intensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, poco intensivi"@it ;
-    rdfs:subClassOf cultivationtype:480 .
+    rdfs:subClassOf cultivationtype:480 ;
+    :intensity :22 .
 
 cultivationtype:1134 a owl:Class ;
     rdfs:label "Heuwiesen im Sömmerungsg., übrige"@de,
@@ -1013,19 +1018,22 @@ cultivationtype:1153 a owl:Class ;
     rdfs:label "Naturwiese mittelintensiv"@de,
         "Prairie naturelle moyennement intensive"@fr,
         "Prato naturale medio-intensivo"@it ;
-    rdfs:subClassOf cultivationtype:2 .
+    rdfs:subClassOf cultivationtype:2 ;
+    :intensity :23 .
 
 cultivationtype:1154 a owl:Class ;
     rdfs:label "Kunstwiese mittelintensiv"@de,
         "Prairie artificielle moyennement intensive"@fr,
         "Prato artificiale medio-intensivo"@it ;
-    rdfs:subClassOf cultivationtype:601 .
+    rdfs:subClassOf cultivationtype:601 ;
+    :intensity :23 .
 
 cultivationtype:1155 a owl:Class ;
     rdfs:label "Naturwiese intensiv"@de,
         "Prairie naturelle intensive"@fr,
         "Prato naturale intensivo"@it ;
-    rdfs:subClassOf cultivationtype:2 .
+    rdfs:subClassOf cultivationtype:2 ;
+    :intensity :24 .
 
 cultivationtype:1156 a owl:Class ;
     rdfs:label "Winterspinat, 1 Schnitt"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -3645,7 +3645,8 @@ cultivationtype:594 a owl:Class ;
     rdfs:comment "Beitragsberechtigte offene Ackerfläche (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Terres ouvertes donnant droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Superficie coltiva aperta, avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:595 a owl:Class ;
     rdfs:label "Nicht beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -3654,7 +3655,8 @@ cultivationtype:595 a owl:Class ;
     rdfs:comment "Nicht beitragsberechtigte übrige offene Ackerfläche (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres terres ouvertes ne donnant pas droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altra superficie coltiva aperta, non avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:597 a owl:Class ;
     rdfs:label "Beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -3824,13 +3826,15 @@ cultivationtype:693 a owl:Class ;
     rdfs:label "Regionsspezifische Biodiversitätsförderflächen (Weiden)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (pascoli)"@it ;
-    rdfs:subClassOf cultivationtype:3 .
+    rdfs:subClassOf cultivationtype:3 ;
+    :intensity :21 .
 
 cultivationtype:694 a owl:Class ;
     rdfs:label "Regionsspezifische Biodiversitätsförderfläche (Grünflächen ohne Weiden)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère, sauf les pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite, senza pascoli)"@it ;
-    rdfs:subClassOf cultivationtype:2 .
+    rdfs:subClassOf cultivationtype:2 ;
+    :intensity :21 .
 
 cultivationtype:697 a owl:Class ;
     rdfs:label "Beitragsberechtigte übrige Dauergrünfläche"@de,
@@ -4009,7 +4013,8 @@ cultivationtype:731 a owl:Class ;
 cultivationtype:735 a owl:Class ;
     rdfs:label "Reben (regionsspezifische Biodiversitätsförderflächen)"@de,
         "Vignes (surfaces de promotion de la biodiversité spécifiques à la ré-gion)"@fr,
-        "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it .
+        "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
+    :intensity :21 .
 
 cultivationtype:75 a owl:Class ;
     rdfs:label "Portulak"@de,
@@ -4233,7 +4238,8 @@ cultivationtype:858 a owl:Class ;
     rdfs:comment "Hecken-, Feld- und Ufergehölze (mit Pufferstreifen) (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Haies, bosquets champêtres et berges boisées (avec la bande tampon) (Surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Siepi, boschetti campestri e rivieraschi (con fascia tampone) (Superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:9 .
+    rdfs:subClassOf cultivationtype:9 ;
+    :intensity :21 .
 
 cultivationtype:86 a owl:Class ;
     rdfs:label "Kohlrabi"@de,
@@ -4343,7 +4349,8 @@ cultivationtype:908 a owl:Class ;
     rdfs:label "Regionsspezifische Biodiversitätsförderflächen"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione"@it ;
-    rdfs:subClassOf cultivationtype:12 .
+    rdfs:subClassOf cultivationtype:12 ;
+    :intensity :21 .
 
 cultivationtype:909 a owl:Class ;
     rdfs:label "Hausgärten"@de,
@@ -4410,13 +4417,15 @@ cultivationtype:927 a owl:Class ;
     rdfs:label "Andere Bäume (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres arbres (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri alberi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:20 ;
+    :intensity :21 .
 
 cultivationtype:928 a owl:Class ;
     rdfs:label "Andere Elemente (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres éléments (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri elementi (superficie per la promozione della biodiversità specifica di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:20 ;
+    :intensity :21 .
 
 cultivationtype:929 a owl:Class ;
     rdfs:label "Andere Elemente (Landschaftsqualität)"@de,
@@ -4597,7 +4606,8 @@ cultivationtype:695 a owl:DeprecatedClass ;
     rdfs:label "Regionsspezifische Biodiversitätsförderfläche (Grünfläche)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite)"@it ;
-    rdfs:subClassOf cultivationtype:21 .
+    rdfs:subClassOf cultivationtype:21 ;
+    :intensity :21 .
 
 cultivationtype:716 a owl:DeprecatedClass ;
     rdfs:label "Gepflegte Selven (Kastanien-/Nussbäume)"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -158,7 +158,7 @@ cultivationtype:1021 a owl:Class ;
 cultivationtype:1023 a owl:Class ;
     rdfs:label "Nützlingsstreifen (DK)"@de ;
     rdfs:subClassOf cultivationtype:6 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:1024 a owl:Class ;
     rdfs:label "Hecken u. Feldgehölze mit Pufferstreifen (keine BFF)"@de ;
@@ -263,7 +263,7 @@ cultivationtype:1042 a owl:Class ;
         "Prairie artificielle intensive"@fr,
         "Prato artificiale intensivo"@it ;
     rdfs:subClassOf cultivationtype:601 ;
-    :intensity intensity:Intensive .
+    :managementIntensity intensity:Intensive .
 
 cultivationtype:1043 a owl:Class ;
     rdfs:label "Kohlrabi (geschützter Anbau)"@de,
@@ -528,7 +528,7 @@ cultivationtype:1080 a owl:Class ;
     rdfs:label "Intensive Weiden und Mähweiden"@de ;
     schema:alternateName "Weide (Mäh-) intensiv"@de ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity intensity:Intensive .
+    :managementIntensity intensity:Intensive .
 
 cultivationtype:1081 a owl:Class ;
     rdfs:label "Stangenbohne (geschützter Anbau)"@de,
@@ -560,7 +560,7 @@ cultivationtype:1085 a owl:Class ;
         "Pascoli e pascoli da sfalcio medio-intensivi"@it ;
     schema:alternateName "Weide (Mäh-) mittelintensiv"@de ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity intensity:Medium .
+    :managementIntensity intensity:Medium .
 
 cultivationtype:1086 a owl:Class ;
     rdfs:label "Schlüsselblume (ganze Pflanze)"@de,
@@ -831,7 +831,7 @@ cultivationtype:1126 a owl:Class ;
         "Pâturages peu intensifs"@fr,
         "Pascoli poco intensivi"@it ;
     rdfs:subClassOf cultivationtype:616 ;
-    :intensity intensity:Low .
+    :managementIntensity intensity:Low .
 
 cultivationtype:1127 a owl:Class ;
     rdfs:label "Bundzwiebeln, Überwinterung"@de,
@@ -875,14 +875,14 @@ cultivationtype:1132 a owl:Class ;
         "Prairies de fauche de la région d'estivage, extensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, estensivi"@it ;
     rdfs:subClassOf cultivationtype:480 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:1133 a owl:Class ;
     rdfs:label "Heuwiesen Sömmerungsg., wenig intensiv"@de,
         "Prairies de fauche de la région d'estivage, peu intensives"@fr,
         "Prati da sfalcio nella regione d'estivazione, poco intensivi"@it ;
     rdfs:subClassOf cultivationtype:480 ;
-    :intensity intensity:Low .
+    :managementIntensity intensity:Low .
 
 cultivationtype:1134 a owl:Class ;
     rdfs:label "Heuwiesen im Sömmerungsg., übrige"@de,
@@ -1021,21 +1021,21 @@ cultivationtype:1153 a owl:Class ;
         "Prairie naturelle moyennement intensive"@fr,
         "Prato naturale medio-intensivo"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity intensity:Medium .
+    :managementIntensity intensity:Medium .
 
 cultivationtype:1154 a owl:Class ;
     rdfs:label "Kunstwiese mittelintensiv"@de,
         "Prairie artificielle moyennement intensive"@fr,
         "Prato artificiale medio-intensivo"@it ;
     rdfs:subClassOf cultivationtype:601 ;
-    :intensity intensity:Medium .
+    :managementIntensity intensity:Medium .
 
 cultivationtype:1155 a owl:Class ;
     rdfs:label "Naturwiese intensiv"@de,
         "Prairie naturelle intensive"@fr,
         "Prato naturale intensivo"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity intensity:Intensive .
+    :managementIntensity intensity:Intensive .
 
 cultivationtype:1156 a owl:Class ;
     rdfs:label "Winterspinat, 1 Schnitt"@de,
@@ -3475,14 +3475,14 @@ cultivationtype:555 a owl:Class ;
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:556 a owl:Class ;
     rdfs:label "Buntbrache"@de,
         "Jachère florale"@fr,
         "Maggese fioriti"@it ;
     rdfs:subClassOf cultivationtype:77 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:557 a owl:Class ;
     rdfs:label "Rotationsbrache"@de,
@@ -3490,7 +3490,7 @@ cultivationtype:557 a owl:Class ;
         "Jachère tournante"@fr,
         "Maggese da rotazione"@it ;
     rdfs:subClassOf cultivationtype:77 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:559 a owl:Class ;
     rdfs:label "Saum auf Ackerflächen"@de,
@@ -3552,7 +3552,7 @@ cultivationtype:572 a owl:Class ;
         "avec des céréales ou de la caméline, au moins 30 % de lentilles lors de la récolte (pour la production de grains)"@fr,
         "Strisce per organismi utili sulla superficie coltiva aperta"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:573 a owl:Class ;
     rdfs:label "Senf"@de,
@@ -3647,7 +3647,7 @@ cultivationtype:594 a owl:Class ;
         "Terres ouvertes donnant droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Superficie coltiva aperta, avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:595 a owl:Class ;
     rdfs:label "Nicht beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -3657,7 +3657,7 @@ cultivationtype:595 a owl:Class ;
         "Autres terres ouvertes ne donnant pas droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altra superficie coltiva aperta, non avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:597 a owl:Class ;
     rdfs:label "Beitragsberechtigte übrige offene Ackerfläche"@de,
@@ -3708,7 +3708,7 @@ cultivationtype:611 a owl:Class ;
         "Les prairies exploitées de manière extensive ne sont pas fertilisées et sont fauchées tardivement, comme par exemple les prairies mi-sèches ou à brome. Elles représentent les herbages les plus riches en espèces de Suisse."@fr,
         "I prati sfruttati in modo estensivo non vengono concimati e vengono falciati tardi, come ad esempio i prati semi-aridi o a brometo. Rappresentano le praterie più ricche di specie della Svizzera."@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:612 a owl:Class ;
     rdfs:label "Wenig intensiv genutzte Wiesen (ohne Weiden)"@de,
@@ -3718,7 +3718,7 @@ cultivationtype:612 a owl:Class ;
         "Les prairies peu intensives sont des prairies légèrement fertilisées et fauchées tardivement, comme par exemple les prairies à fromental ou à avoine dorée."@fr,
         "I prati poco intensivi sono prati leggermente concimati e falciati tardi, come ad esempio i prati a fromental o ad avena bionda."@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity intensity:Low .
+    :managementIntensity intensity:Low .
 
 cultivationtype:613 a owl:Class ;
     rdfs:label "Übrige Dauerwiesen (ohne Weiden)"@de,
@@ -3737,7 +3737,7 @@ cultivationtype:617 a owl:Class ;
         "Pâturages extensifs"@fr,
         "Pascoli estensivi"@it ;
     rdfs:subClassOf cultivationtype:3 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:618 a owl:Class ;
     rdfs:label "Waldweiden (ohne bewaldete Fläche)"@de,
@@ -3828,14 +3828,14 @@ cultivationtype:693 a owl:Class ;
         "Surfaces de promotion de la biodiversité spécifiques à la région (pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (pascoli)"@it ;
     rdfs:subClassOf cultivationtype:3 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:694 a owl:Class ;
     rdfs:label "Regionsspezifische Biodiversitätsförderfläche (Grünflächen ohne Weiden)"@de,
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère, sauf les pâturages)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite, senza pascoli)"@it ;
     rdfs:subClassOf cultivationtype:2 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:697 a owl:Class ;
     rdfs:label "Beitragsberechtigte übrige Dauergrünfläche"@de,
@@ -4015,7 +4015,7 @@ cultivationtype:735 a owl:Class ;
     rdfs:label "Reben (regionsspezifische Biodiversitätsförderflächen)"@de,
         "Vignes (surfaces de promotion de la biodiversité spécifiques à la ré-gion)"@fr,
         "Vigna (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:75 a owl:Class ;
     rdfs:label "Portulak"@de,
@@ -4240,7 +4240,7 @@ cultivationtype:858 a owl:Class ;
         "Haies, bosquets champêtres et berges boisées (avec la bande tampon) (Surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Siepi, boschetti campestri e rivieraschi (con fascia tampone) (Superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:9 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:86 a owl:Class ;
     rdfs:label "Kohlrabi"@de,
@@ -4351,7 +4351,7 @@ cultivationtype:908 a owl:Class ;
         "Surfaces de promotion de la biodiversité spécifiques à la région"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione"@it ;
     rdfs:subClassOf cultivationtype:12 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:909 a owl:Class ;
     rdfs:label "Hausgärten"@de,
@@ -4419,14 +4419,14 @@ cultivationtype:927 a owl:Class ;
         "Autres arbres (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri alberi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
     rdfs:subClassOf cultivationtype:20 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:928 a owl:Class ;
     rdfs:label "Andere Elemente (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres éléments (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altri elementi (superficie per la promozione della biodiversità specifica di una regione)"@it ;
     rdfs:subClassOf cultivationtype:20 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:929 a owl:Class ;
     rdfs:label "Andere Elemente (Landschaftsqualität)"@de,
@@ -4488,7 +4488,7 @@ cultivationtype:950 a owl:Class ;
         "Bande culturale extensive"@fr,
         "Fasce di colture estensive in campicoltura"@it ;
     rdfs:subClassOf :Cultivation ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:951 a owl:Class ;
     rdfs:label "Getreide in weiter Reihe"@de,
@@ -4572,14 +4572,14 @@ cultivationtype:564 a owl:DeprecatedClass ;
         "Bande culturale extensive Oléagineux (colza, tournesols, lin)"@fr,
         "Fasce di colture estensive in campicoltura - semi oleosi (colza, girasole, lino)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:565 a owl:DeprecatedClass ;
     rdfs:label "Ackerschonstreifen Getreide"@de,
         "Bande culturale extensive céréales"@fr,
         "Fasce di colture estensive in campicoltura - cereali"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:571 a owl:DeprecatedClass ;
     rdfs:label "Ackerschonstreifen Körnerleguminosen"@de,
@@ -4589,7 +4589,7 @@ cultivationtype:571 a owl:DeprecatedClass ;
         "Bande culturale extensive Légumineuses (féveroles, pois protéagineux, lupins et méteils du code 569)"@fr,
         "Fasce di colture estensive in campicoltura - leguminose a granelli (favette, piselli proteici, lupini e miscele con codice 569)"@it ;
     rdfs:subClassOf cultivationtype:1 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:619 a owl:DeprecatedClass ;
     rdfs:label "Weiden für Schweine, nicht anrechenbar für die Berechnung der RGVE"@de,
@@ -4608,7 +4608,7 @@ cultivationtype:695 a owl:DeprecatedClass ;
         "Surfaces de promotion de la biodiversité spécifiques à la région (Surface herbagère)"@fr,
         "Superfici per la promozione della biodiversità specifiche di una regione (superfici inerbite)"@it ;
     rdfs:subClassOf cultivationtype:21 ;
-    :intensity intensity:Extensive .
+    :managementIntensity intensity:Extensive .
 
 cultivationtype:716 a owl:DeprecatedClass ;
     rdfs:label "Gepflegte Selven (Kastanien-/Nussbäume)"@de,
@@ -4650,7 +4650,7 @@ cultivationtype:shape a sh:NodeShape ;
             sh:path :botanicalPlant ],
         [ sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path :intensity ],
+            sh:path :managementIntensity ],
         [ sh:node cultivationtype:shape ;
             sh:nodeKind sh:IRI ;
             sh:path owl:disjointWith ],

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -156,7 +156,8 @@ cultivationtype:1021 a owl:Class ;
 
 cultivationtype:1023 a owl:Class ;
     rdfs:label "Nützlingsstreifen (DK)"@de ;
-    rdfs:subClassOf cultivationtype:6 .
+    rdfs:subClassOf cultivationtype:6 ;
+    :intensity :21 .
 
 cultivationtype:1024 a owl:Class ;
     rdfs:label "Hecken u. Feldgehölze mit Pufferstreifen (keine BFF)"@de ;
@@ -3479,14 +3480,16 @@ cultivationtype:556 a owl:Class ;
     rdfs:label "Buntbrache"@de,
         "Jachère florale"@fr,
         "Maggese fioriti"@it ;
-    rdfs:subClassOf cultivationtype:77 .
+    rdfs:subClassOf cultivationtype:77 ;
+    :intensity :21 .
 
 cultivationtype:557 a owl:Class ;
     rdfs:label "Rotationsbrache"@de,
         "Rotational fallow"@en,
         "Jachère tournante"@fr,
         "Maggese da rotazione"@it ;
-    rdfs:subClassOf cultivationtype:77 .
+    rdfs:subClassOf cultivationtype:77 ;
+    :intensity :21 .
 
 cultivationtype:559 a owl:Class ;
     rdfs:label "Saum auf Ackerflächen"@de,
@@ -3547,7 +3550,8 @@ cultivationtype:572 a owl:Class ;
     rdfs:label "Nützlingsstreifen auf offener Ackerfläche"@de,
         "avec des céréales ou de la caméline, au moins 30 % de lentilles lors de la récolte (pour la production de grains)"@fr,
         "Strisce per organismi utili sulla superficie coltiva aperta"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:1 ;
+    :intensity :21 .
 
 cultivationtype:573 a owl:Class ;
     rdfs:label "Senf"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -3666,7 +3666,7 @@ cultivationtype:597 a owl:Class ;
     rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:598 a owl:Class ;
-    rdfs:label "Nicht beitragsberechtigte Übrige offene Ackerfläche"@de,
+    rdfs:label "Nicht beitragsberechtigte übrige offene Ackerfläche"@de,
         "Autres terres ouvertes sans contributions"@fr,
         "Altra superficie coltiva aperta, senza contributi"@it ;
     rdfs:subClassOf cultivationtype:1 .


### PR DESCRIPTION
## Changes

- Replace `rdfs:label` and `rdfs:comment` with `schema:name` and `schema:description`.
- Update and clean the master prefix definition file (`rdf/ontology/prefixes.ttl`)
  - Add `taxon:` prefix definition.
  - Add `intensity:` prefix definition.
- Add intensity scores for all crops where information about it is available or can be somewhat interpreted...
- Rename intensity scores. Makes data interpretation easier if you look at only the `.ttl` file...
  - `:21` to `intensity:Extensive`
  - `:22` to `intensity:Low`
  - `:23` to `intensity:Medium`
  - `:24` to `intensity:Intensive`
- Rename `:intensity`  property to `:managementIntensity`.
- Renamed some rather illegible AGIS crops.

## Demo query

Query to get all cultivation types with a specified management intensity.

``` rq
PREFIX intensity: <https://agriculture.ld.admin.ch/crops/intensity/>
PREFIX : <https://agriculture.ld.admin.ch/crops/>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX schema: <http://schema.org/>
PREFIX owl: <http://www.w3.org/2002/07/owl#>
SELECT *
FROM <https://lindas.admin.ch/foag/crops>
WHERE {
  ?crop a ?class ;
    rdfs:subClassOf* :Cultivation ;
    schema:name ?name ;
    :managementIntensity ?intensity .
  FILTER(LANG(?name)="de")
}
ORDER BY ?name
```