### PR TITLE
Integrate the last PSM crops that broadly refer to some land use

### DIFF
--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -1289,7 +1289,7 @@ psm:181 a cube:Observation ;
         "semis sous litière"@fr,
         "Semine a lattiera"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:181 .
 
 psm:182 a cube:Observation ;
     schema:identifier "4E1ACD79-F162-4EBB-93CB-C6857A811E9C"^^xsd:ID ;
@@ -2320,7 +2320,7 @@ psm:284 a cube:Observation ;
         "semis après travail superficiel"@fr,
         "Semine dopo la fresatura"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:284 .
 
 psm:285 a cube:Observation ;
     schema:identifier "DA71526F-AC1D-40F1-8EF5-109E3F3FFD76"^^xsd:ID ;
@@ -3140,7 +3140,7 @@ psm:64 a cube:Observation ;
         "techniques culturales"@fr,
         "Tecnica di coltivazione"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:64 .
 
 psm:65 a cube:Observation ;
     schema:identifier "E8B23A5E-B65E-4DC8-977D-BD84F143A442"^^xsd:ID ;

--- a/rdf/data/srppp.ttl
+++ b/rdf/data/srppp.ttl
@@ -1413,7 +1413,7 @@ psm:194 a cube:Observation ;
         "domaine surfaces de compensation écologique (selon OPD)"@fr,
         "Superfici di compensazione ecologica in generale (conformemente OPD)"@it ;
     schema:version 0 ;
-    :cultivationType cube:Undefined .
+    :cultivationType cultivationtype:414 .
 
 psm:195 a cube:Observation ;
     schema:identifier "61D9C648-0736-43D4-BF04-B8643B1D74E0"^^xsd:ID ;

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -1868,7 +1868,7 @@ cultivationtype:413 a owl:Class ;
 cultivationtype:414 a owl:Class ;
     schema:name "Biodiversitätsförderfläche"@de ;
     schema:alternateName "Ökologischen Ausgleichsflächen"@de ;
-    schema:subClassOf :Cultivation .
+    rdfs:subClassOf :Cultivation .
 
 cultivationtype:468 a owl:Class ;
     schema:name "Ackerbohne"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -1865,6 +1865,11 @@ cultivationtype:413 a owl:Class ;
         "Cappuccio bianco"@it ;
     rdfs:subClassOf cultivationtype:81 .
 
+cultivationtype:414 a owl:Class ;
+    schema:name "Biodiversitätsförderfläche"@de ;
+    schema:alternateName "Ökologischen Ausgleichsflächen"@de ;
+    schema:subClassOf :Cultivation .
+
 cultivationtype:468 a owl:Class ;
     schema:name "Ackerbohne"@de,
         "féverole"@fr,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -449,6 +449,10 @@ cultivationtype:63 a owl:Class ;
     rdfs:subClassOf cultivationtype:402,
         cultivationtype:72 .
 
+cultivationtype:64 a owl:Class ;
+    schema:name "Durch Anbautechnik bestimmte Kulturen"@de ;
+    rdfs:subClassOf cultivationtype:1 .
+
 cultivationtype:65 a owl:Class ;
     schema:name "Primeln"@de,
         "primevères"@fr,
@@ -1021,6 +1025,12 @@ cultivationtype:179 a owl:Class ;
         "Indivia"@it ;
     rdfs:subClassOf cultivationtype:141 .
 
+cultivationtype:181 a owl:Class ;
+    schema:name "Mulchsaaten"@de,
+        "semis sous litière"@fr,
+        "Semine a lattiera"@it ;
+    rdfs:subClassOf cultivationtype:64 .
+
 cultivationtype:182 a owl:Class ;
     schema:name "Kleegrasmischung (Kunstwiese)"@de,
         "mélange trèfles-graminées (prairie arificielle)"@fr,
@@ -1499,6 +1509,12 @@ cultivationtype:283 a owl:Class ;
         "cerisier"@fr,
         "Ciliegio"@it ;
     rdfs:subClassOf cultivationtype:704 .
+
+cultivationtype:284 a owl:Class ;
+    schema:name "Frässaaten"@de,
+        "semis après travail superficiel"@fr,
+        "Semine dopo la fresatura"@it ;
+    rdfs:subClassOf cultivationtype:64 .
 
 cultivationtype:287 a owl:Class ;
     schema:name "Melisse"@de,

--- a/rdf/ontology/cultivationtypes.ttl
+++ b/rdf/ontology/cultivationtypes.ttl
@@ -1029,6 +1029,7 @@ cultivationtype:181 a owl:Class ;
     schema:name "Mulchsaaten"@de,
         "semis sous litière"@fr,
         "Semine a lattiera"@it ;
+    schema:description "Eine Mulchsaat ist ein landwirtschaftliches Aussaatverfahren der sogenannten konservierenden Bodenbearbeitung. Bei dieser Methode wird das Saatgut in einen Boden eingebracht, der noch von den Pflanzenresten (Mulch) der Vorfrucht oder einer Zwischenfrucht bedeckt ist."@de ;
     rdfs:subClassOf cultivationtype:64 .
 
 cultivationtype:182 a owl:Class ;
@@ -1514,6 +1515,7 @@ cultivationtype:284 a owl:Class ;
     schema:name "Frässaaten"@de,
         "semis après travail superficiel"@fr,
         "Semine dopo la fresatura"@it ;
+    schema:description "Eine Frässaat ist ein bodenschonendes, landwirtschaftliches Aussaatverfahren. Es kommt hauptsächlich bei der Grünlanderneuerung, der Nachsaat von lückenhaften Wiesen und Weiden oder beim Anbau von Zwischenfrüchten zum Einsatz."@de ;
     rdfs:subClassOf cultivationtype:64 .
 
 cultivationtype:287 a owl:Class ;

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -2965,7 +2965,7 @@ cultivationtype:413 a owl:Class ;
 cultivationtype:414 a owl:Class ;
     rdfs:label "Biodiversitätsförderfläche"@de ;
     schema:alternateName "Ökologischen Ausgleichsflächen"@de ;
-    schema:subClassOf :Cultivation .
+    rdfs:subClassOf :Cultivation .
 
 cultivationtype:43 a owl:Class ;
     rdfs:label "Jostabeere"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -886,7 +886,7 @@ cultivationtype:1133 a owl:Class ;
 
 cultivationtype:1134 a owl:Class ;
     rdfs:label "Heuwiesen im Sömmerungsg., übrige"@de,
-        "Prairies de fauche de la région d'estivage, autres"@fr,
+        "Prairies de fauche dans la région d'estivage, autres"@fr,
         "Prati da sfalcio nella regione d'estivazione, altri"@it ;
     rdfs:subClassOf cultivationtype:480 .
 
@@ -1121,12 +1121,6 @@ cultivationtype:1168 a owl:Class ;
         "Zucchine, seminate, estate e autunno"@it ;
     rdfs:subClassOf cultivationtype:225 .
 
-cultivationtype:1169 a owl:Class ;
-    rdfs:label "Heuwiesen im Sömmerungsg., übrige"@de,
-        "Prairies de fauche dans la région d'estivage, autres"@fr,
-        "Prati da sfalcio nella regione d'estivazione, altri"@it ;
-    rdfs:subClassOf cultivationtype:480 .
-
 cultivationtype:117 a owl:Class ;
     rdfs:label "Stachys"@de,
         "crosnes du japon"@fr,
@@ -1154,10 +1148,6 @@ cultivationtype:1182 a owl:Class ;
 cultivationtype:1183 a owl:Class ;
     rdfs:label "Blumenkohl, Verarbeitung"@de ;
     rdfs:subClassOf cultivationtype:111 .
-
-cultivationtype:1184 a owl:Class ;
-    rdfs:label "Aubergine, Erdkultur (geschützter Anbau)"@de ;
-    owl:intersectionOf ( cultivationtype:7 cultivationtype:474 ) .
 
 cultivationtype:1185 a owl:Class ;
     rdfs:label "Brombeeren, 2.0 kg/m2"@de ;
@@ -1949,7 +1939,7 @@ cultivationtype:171 a owl:Class ;
     rdfs:label "Bohnen ohne Hülsen"@de,
         "Haricots écossés"@fr,
         "Fagioli senza baccello"@it ;
-    rdfs:subClassOf cultivationtype:3 .
+    rdfs:subClassOf cultivationtype:476 .
 
 cultivationtype:172 a owl:Class ;
     rdfs:label "Lorbeer"@de,
@@ -1986,6 +1976,12 @@ cultivationtype:179 a owl:Class ;
 cultivationtype:18 a owl:Class ;
     rdfs:label "Mischkultur"@de ;
     rdfs:subClassOf cultivationtype:1 .
+
+cultivationtype:181 a owl:Class ;
+    rdfs:label "Mulchsaaten"@de,
+        "semis sous litière"@fr,
+        "Semine a lattiera"@it ;
+    rdfs:subClassOf cultivationtype:64 .
 
 cultivationtype:182 a owl:Class ;
     rdfs:label "Kleegrasmischung (Kunstwiese)"@de,
@@ -2273,7 +2269,7 @@ cultivationtype:237 a owl:Class ;
     rdfs:label "Markstammkohl"@de,
         "chou moellier"@fr,
         "Cavolo fustoso"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:475 .
 
 cultivationtype:238 a owl:Class ;
     rdfs:label "Nelken"@de,
@@ -2522,6 +2518,12 @@ cultivationtype:283 a owl:Class ;
         "Ciliegio"@it ;
     rdfs:subClassOf cultivationtype:704 .
 
+cultivationtype:284 a owl:Class ;
+    rdfs:label "Frässaaten"@de,
+        "semis après travail superficiel"@fr,
+        "Semine dopo la fresatura"@it ;
+    rdfs:subClassOf cultivationtype:64 .
+
 cultivationtype:287 a owl:Class ;
     rdfs:label "Melisse"@de,
         "mélisse"@fr,
@@ -2742,7 +2744,7 @@ cultivationtype:325 a owl:Class ;
     rdfs:label "Pak-Choi"@de,
         "pakchoi"@fr,
         "Pak-Choi"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:475 .
 
 cultivationtype:326 a owl:Class ;
     rdfs:label "Rubus Arten"@de,
@@ -3606,7 +3608,7 @@ cultivationtype:58 a owl:Class ;
     rdfs:label "Chinakohl"@de,
         "chou de Chine"@fr,
         "Cavolo cinese"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:475 .
 
 cultivationtype:580 a owl:Class ;
     rdfs:label "Sorghum zur Körnergewinnung"@de,
@@ -3796,6 +3798,10 @@ cultivationtype:635 a owl:Class ;
         "Prairies riveraines (sauf les pâturages)"@fr,
         "Prati rivieraschi (senza pascoli)"@it ;
     rdfs:subClassOf cultivationtype:2 .
+
+cultivationtype:64 a owl:Class ;
+    rdfs:label "Durch Anbautechnik bestimmte Kulturen"@de ;
+    rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:65 a owl:Class ;
     rdfs:label "Primeln"@de,
@@ -4272,7 +4278,7 @@ cultivationtype:87 a owl:Class ;
     rdfs:label "Federkohl"@de,
         "chou frisé non pommé"@fr,
         "Cavolo piuma"@it ;
-    rdfs:subClassOf cultivationtype:20 .
+    rdfs:subClassOf cultivationtype:475 .
 
 cultivationtype:88 a owl:Class ;
     rdfs:label "Speise- und Futterkartoffeln"@de,

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -1981,6 +1981,7 @@ cultivationtype:181 a owl:Class ;
     rdfs:label "Mulchsaaten"@de,
         "semis sous litière"@fr,
         "Semine a lattiera"@it ;
+    rdfs:comment "Eine Mulchsaat ist ein landwirtschaftliches Aussaatverfahren der sogenannten konservierenden Bodenbearbeitung. Bei dieser Methode wird das Saatgut in einen Boden eingebracht, der noch von den Pflanzenresten (Mulch) der Vorfrucht oder einer Zwischenfrucht bedeckt ist."@de ;
     rdfs:subClassOf cultivationtype:64 .
 
 cultivationtype:182 a owl:Class ;
@@ -2522,6 +2523,7 @@ cultivationtype:284 a owl:Class ;
     rdfs:label "Frässaaten"@de,
         "semis après travail superficiel"@fr,
         "Semine dopo la fresatura"@it ;
+    rdfs:comment "Eine Frässaat ist ein bodenschonendes, landwirtschaftliches Aussaatverfahren. Es kommt hauptsächlich bei der Grünlanderneuerung, der Nachsaat von lückenhaften Wiesen und Weiden oder beim Anbau von Zwischenfrüchten zum Einsatz."@de ;
     rdfs:subClassOf cultivationtype:64 .
 
 cultivationtype:287 a owl:Class ;

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -2962,6 +2962,11 @@ cultivationtype:413 a owl:Class ;
         "Cavolo bianco"@it ;
     rdfs:subClassOf cultivationtype:81 .
 
+cultivationtype:414 a owl:Class ;
+    rdfs:label "Biodiversitätsförderfläche"@de ;
+    schema:alternateName "Ökologischen Ausgleichsflächen"@de ;
+    schema:subClassOf :Cultivation .
+
 cultivationtype:43 a owl:Class ;
     rdfs:label "Jostabeere"@de,
         "josta"@fr,


### PR DESCRIPTION
## Changes

- Added and renamed "Anbautechnik"
- Added "Mulchsaaten" + definition
- Added "Frässaaten" + definition
- Added "Biodiversitätsförderfläche", linked "Ökologische Ausgleichsflächen" to that (name changed with AP 14-17

Closes blw-ofag-ufag/eCH-0265#304 