### PR TITLE
Update SHACL data model

### DIFF
--- a/rdf/ontology/core.ttl
+++ b/rdf/ontology/core.ttl
@@ -57,7 +57,8 @@
     rdfs:subClassOf owl:Class .
 
 :DeprecatedCultivationType a owl:Class ;
-    rdfs:subClassOf owl:DeprecatedClass .
+    rdfs:subClassOf :CultivationType,
+        owl:DeprecatedClass .
 
 :DirectPaymentCrop a owl:Class ;
     rdfs:subClassOf cube:Observation .

--- a/rdf/processed/crop-taxonomy.ttl
+++ b/rdf/processed/crop-taxonomy.ttl
@@ -9,9 +9,6 @@
 @prefix taxon: <https://agriculture.ld.admin.ch/crops/taxon/> .
 
 [] a owl:AllDisjointClasses ;
-    owl:members ( cultivationtype:1 cultivationtype:4 cultivationtype:5 cultivationtype:6 cultivationtype:7 cultivationtype:8 cultivationtype:9 cultivationtype:10 cultivationtype:12 cultivationtype:13 cultivationtype:20 cultivationtype:21 ) .
-
-[] a owl:AllDisjointClasses ;
     owl:members ( cultivationtype:504 cultivationtype:505 cultivationtype:509 cultivationtype:514 cultivationtype:515 cultivationtype:542 cultivationtype:543 cultivationtype:549 ) .
 
 [] a owl:AllDisjointClasses ;
@@ -97,6 +94,9 @@
 
 [] a owl:AllDisjointClasses ;
     owl:members ( cultivationtype:545 cultivationtype:546 cultivationtype:801 cultivationtype:806 ) .
+
+[] a owl:AllDisjointClasses ;
+    owl:members ( cultivationtype:1 cultivationtype:4 cultivationtype:5 cultivationtype:6 cultivationtype:7 cultivationtype:8 cultivationtype:9 cultivationtype:10 cultivationtype:12 cultivationtype:13 cultivationtype:20 cultivationtype:21 ) .
 
 cultivationtype:1 a owl:Class ;
     rdfs:label "Ackerfläche"@de,
@@ -339,13 +339,17 @@ cultivationtype:1043 a owl:Class ;
     rdfs:label "Kohlrabi (geschützter Anbau)"@de,
         "Chou-rave (culture protégée)"@fr,
         "Cavolo rapa (coltura protetta)"@it ;
-    owl:intersectionOf ( cultivationtype:86 cultivationtype:23 ) .
+    rdfs:subClassOf cultivationtype:23,
+        cultivationtype:86 ;
+    owl:disjointWith cultivationtype:1296 .
 
 cultivationtype:1044 a owl:Class ;
     rdfs:label "Verarbeitungskohlrabi"@de,
         "Chou-rave d'industrie"@fr,
         "Cavolo rapa da industria"@it ;
-    owl:intersectionOf ( cultivationtype:86 cultivationtype:546 ) .
+    rdfs:subClassOf cultivationtype:1296,
+        cultivationtype:546 ;
+    owl:disjointWith cultivationtype:1297 .
 
 cultivationtype:1045 a owl:Class ;
     rdfs:label "Ölhanf"@de,
@@ -672,7 +676,9 @@ cultivationtype:1096 a owl:Class ;
     rdfs:label "Radicchio und Cicorino für Verarbeitung"@de,
         "Radicchio et cicorino d'industrie"@fr,
         "Radicchio e cicorino da industria"@it ;
-    rdfs:subClassOf cultivationtype:133 .
+    rdfs:subClassOf cultivationtype:133,
+        cultivationtype:546 ;
+    owl:disjointWith cultivationtype:1298 .
 
 cultivationtype:1097 a owl:Class ;
     rdfs:label "Himbeer-Jungpflanzen (Long-Cane)"@de,
@@ -1720,6 +1726,53 @@ cultivationtype:1292 a owl:Class ;
     rdfs:label "Hecken und Feldgehölz mit Krautsaum"@de ;
     rdfs:subClassOf cultivationtype:852 .
 
+cultivationtype:1293 a owl:Class ;
+    rdfs:label "Zuckerhut (Nicht-Convenience)"@de,
+        "Chicorée pain de sucre (non-convenience)"@fr,
+        "Cicoria pan di zucchero (non-convenience)"@it ;
+    rdfs:subClassOf cultivationtype:142 ;
+    owl:disjointWith cultivationtype:1131 .
+
+cultivationtype:1294 a owl:Class ;
+    rdfs:label "Tomaten (Freiland)"@de,
+        "Tomates (pleine terre)"@fr,
+        "Pomodori (pieno campo)"@it ;
+    rdfs:subClassOf cultivationtype:24,
+        cultivationtype:85 ;
+    owl:disjointWith cultivationtype:1141 .
+
+cultivationtype:1295 a owl:Class ;
+    rdfs:label "Krautstiel (Freiland)"@de,
+        "Bette à côte (pleine terre)"@fr,
+        "Costa (pieno campo)"@it ;
+    rdfs:subClassOf cultivationtype:24,
+        cultivationtype:76 ;
+    owl:disjointWith cultivationtype:1135 .
+
+cultivationtype:1296 a owl:Class ;
+    rdfs:label "Kohlrabi Freiland"@de,
+        "Chou-rave de plein champ"@fr,
+        "Cavolo rapa di pieno campo"@it ;
+    rdfs:subClassOf cultivationtype:24,
+        cultivationtype:86 ;
+    owl:disjointWith cultivationtype:1043 .
+
+cultivationtype:1297 a owl:Class ;
+    rdfs:label "Kohlrabi (nicht für die Verarbeitung)"@de,
+        "Chou-rave (pas pour l'industrie)"@fr,
+        "Cavolo rapa (non da industria)"@it ;
+    rdfs:subClassOf cultivationtype:1296,
+        cultivationtype:545 ;
+    owl:disjointWith cultivationtype:1044 .
+
+cultivationtype:1298 a owl:Class ;
+    rdfs:label "Radicchio und Cicorino (nicht für die Verarbeitung)"@de,
+        "Radicchio et cicorino (pas pour l'industrie)"@fr,
+        "Radicchio e cicorino (non da industria)"@it ;
+    rdfs:subClassOf cultivationtype:133,
+        cultivationtype:24 ;
+    owl:disjointWith cultivationtype:1096 .
+
 cultivationtype:13 a owl:Class ;
     rdfs:label "Sömmerungsfläche"@de,
         "Surface d’estivage"@fr,
@@ -2014,9 +2067,9 @@ cultivationtype:187 a owl:Class ;
     rdfs:subClassOf cultivationtype:400 .
 
 cultivationtype:188 a owl:Class ;
-    rdfs:label "Liliengewächse (Liliaceae)"@de,
-        "liliacées"@fr,
-        "Liliacee"@it ;
+    rdfs:label "Amaryllisgewächse (Amaryllidaceae)"@de,
+        "Amaryllidacées (Amaryllidaceae)"@fr,
+        "Amarillidacee (Amaryllidaceae)"@it ;
     rdfs:subClassOf cultivationtype:22 .
 
 cultivationtype:189 a owl:Class ;
@@ -2995,8 +3048,7 @@ cultivationtype:466 a owl:Class ;
 
 cultivationtype:467 a owl:Class ;
     rdfs:label "Dauerkulturen"@de ;
-    rdfs:subClassOf :Cultivation ;
-    owl:unionOf ( cultivationtype:797 cultivationtype:798 ) .
+    rdfs:subClassOf :Cultivation .
 
 cultivationtype:468 a owl:Class ;
     rdfs:label "Ackerbohne"@de,
@@ -3146,7 +3198,8 @@ cultivationtype:5 a owl:Class ;
     rdfs:label "Obstanlagen"@de,
         "Cultures fruitières"@fr,
         "Frutteti"@it ;
-    rdfs:subClassOf cultivationtype:465 .
+    rdfs:subClassOf cultivationtype:465,
+        cultivationtype:467 .
 
 cultivationtype:500 a owl:Class ;
     rdfs:label "Emmer"@de,
@@ -3698,7 +3751,7 @@ cultivationtype:6 a owl:Class ;
     rdfs:label "Übrige Dauerkulturen"@de,
         "Autres cultures pérennes"@fr,
         "Altre colture perenni"@it ;
-    rdfs:subClassOf :Cultivation .
+    rdfs:subClassOf cultivationtype:467 .
 
 cultivationtype:60 a owl:Class ;
     rdfs:label "Sommerflor"@de,

--- a/rdf/shape/data-model.ttl
+++ b/rdf/shape/data-model.ttl
@@ -3,7 +3,7 @@
 # ==============================================================================
 
 # Local prefixes ---------------------------------------------------------------
-@prefix : <https://agriculture.ld.admin.ch/eCH/0265/> .
+@prefix : <https://agriculture.ld.admin.ch/crops/> .
 @prefix shape: <https://agriculture.ld.admin.ch/crops/shape/> .
 @prefix cultivationtype: <https://agriculture.ld.admin.ch/crops/cultivationtype/> .
 @prefix intensity: <https://agriculture.ld.admin.ch/crops/intensity/> .

--- a/rdf/shape/data-model.ttl
+++ b/rdf/shape/data-model.ttl
@@ -3,7 +3,7 @@
 # ==============================================================================
 
 # Local prefixes ---------------------------------------------------------------
-@prefix : <https://agriculture.ld.admin.ch/crops/> .
+@prefix : <https://agriculture.ld.admin.ch/eCH/0265/> .
 @prefix shape: <https://agriculture.ld.admin.ch/crops/shape/> .
 @prefix cultivationtype: <https://agriculture.ld.admin.ch/crops/cultivationtype/> .
 @prefix intensity: <https://agriculture.ld.admin.ch/crops/intensity/> .
@@ -38,7 +38,7 @@ shape: a owl:Ontology ;
     dcterms:title "RDF master and reference data about crops"@en ;
     dcterms:created "2026-03-05"^^xsd:date ;
     dcterms:modified "2026-05-04"^^xsd:date ;
-    dcterms:description
+    dcterms:abstract
 """
 This project addresses the challenge of fragmented agricultural crop data within the Swiss federal administration, where essential systems all use separate, non-harmonized crop terminologies.
 This lack of a "single source of truth" creates significant integration hurdles for digital tools.
@@ -125,7 +125,7 @@ shape:CultivationType a sh:NodeShape ;
         sh:order 8 ;
         sh:path owl:disjointWith ;
         sh:nodeKind sh:IRI ;
-        sh:node shape:CultivationType ;
+        sh:class :CultivationType ;
     ],
     [
         sh:order 9 ;
@@ -195,17 +195,9 @@ shape:DirectPaymentCrop a sh:NodeShape ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:path :cultivationGroup ;
-            sh:node shape:CultivationType ;
+            sh:class :CultivationType ;
         ],
-        [
-            sh:order 4 ;
-            sh:name "Kultur"@de ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path :cultivationType ;
-            sh:node shape:CultivationType
-        ],
+        shape:cultivationType,
         [
             sh:order 5 ;
             sh:name "Gültig von"@de ;
@@ -238,16 +230,7 @@ shape:NutrientBalanceCrop a sh:NodeShape ;
     sh:ignoredProperties ( rdf:type ) ;
     sh:targetClass :NutrientBalanceCrop ;
     sh:property
-        [
-            sh:order 1 ;
-            sh:name "Identifikator"@de,
-                "Identifier"@en ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:path schema:identifier ;
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-        ],
+        shape:identifier,
         [
             sh:order 2 ;
             sh:name "Bezeichnung"@de,
@@ -264,9 +247,8 @@ shape:NutrientBalanceCrop a sh:NodeShape ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:node shape:CultivationType ;
+            sh:class :CultivationType ;
             sh:path :cultivationCategory ;
-            sh:node shape:CultivationCategory ;
         ],
         [
             sh:order 4 ;
@@ -274,24 +256,10 @@ shape:NutrientBalanceCrop a sh:NodeShape ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:node shape:CultivationType ;
+            sh:class :CultivationType ;
             sh:path :cultivationSubCategory ;
-            sh:node shape:CultivationSubCategory ;
         ],
-        [
-            sh:order 5 ;
-            sh:name "Kultur"@de,
-                "Crop"@en ;
-            a cube:KeyDimension ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path :cultivationType ;
-            sh:or (
-                [ sh:node shape:CultivationType ]
-                [ sh:hasValue cube:Undefined ]
-            ) ;
-        ],
+        shape:cultivationType,
         [
             a cube:MeasureDimension ;
             sh:order 6 ;
@@ -352,18 +320,7 @@ shape:PlantProtectionCrop a sh:NodeShape ;
     sh:ignoredProperties ( rdf:type ) ;
     sh:targetClass :PlantProtectionCrop ;
     sh:property
-        [
-            sh:order 1 ;
-            a cube:KeyDimension ;
-            sh:name "Identifikator"@de ;
-            sh:description "Der Identifikator aus Infofito. Neu ist das eine UUID."@de ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:path schema:identifier ;
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:pattern "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" ;
-        ],
+        shape:identifier,
         [
             sh:order 2 ;
             sh:name "Name"@de ;
@@ -375,19 +332,7 @@ shape:PlantProtectionCrop a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:path schema:name ;
         ],
-        [
-            sh:order 3 ;
-            sh:name "Kultur"@de ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path :cultivationType ;
-            sh:or (
-                [ sh:node shape:CultivationType ]
-                [ sh:hasValue cube:Undefined ]
-                [ sh:hasValue :Cultivation ]
-            ) ;
-        ],
+        shape:cultivationType,
         [
             sh:order 4 ;
             sh:name "Version"@de ;
@@ -406,4 +351,40 @@ shape:PlantProtectionCrop a sh:NodeShape ;
             sh:maxCount 2 ;
             sh:nodeKind sh:IRI ;
             sh:class :PlantProtectionCrop ;
+        ],
+        [
+            sh:order 7 ;
+            sh:name "Child crop"@en,
+                "Unterkultur"@de ;
+            sh:path schema:hasPart ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:IRI ;
+            sh:class :PlantProtectionCrop ;
         ] .
+
+# ==============================================================================
+# GENERIC PROPERTIES TO BE RE-USED
+# ==============================================================================
+
+shape:identifier a sh:PropertyShape ;
+    sh:name "Identifier"@en,
+        "Identifikator"@de ;
+    sh:order 1 ;
+    sh:path schema:identifier ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:nodeKind sh:Literal ;
+    sh:datatype xsd:string .
+
+shape:cultivationType a sh:PropertyShape ;
+    sh:order 0 ;
+    sh:name "Kultivierungstyp"@de, "Cultivation type"@en ;
+    sh:description "The corresponding cultivation type in the crops ontology that semantically describes this crop."@en ;
+    sh:path :cultivationType ;
+    sh:class :CultivationType ;
+    sh:minCount 0 ;
+    sh:maxCount 1 ;
+    sh:or (
+        [ sh:class :CultivationType ]
+        [ sh:hasValue cube:Undefined ]
+    ) .

--- a/src/pipeline.bash
+++ b/src/pipeline.bash
@@ -23,8 +23,7 @@ python src/python/rdf-processing.py \
 
 
 echo "Check graph shape using SHACL"
-pyshacl rdf/ontology/cultivationtypes.ttl --shapes rdf/shape/metadata-quality.ttl --format human
-
+pyshacl rdf/processed/graph.ttl --shapes rdf/shape/data-model.ttl --format human
 
 echo "Delete existing data from LINDAS"
 curl \


### PR DESCRIPTION
- Declare `:DeprecatedCultivationType` a subclass of `:CultivationType`
- Use `sh:class` instead of `sh:node`, prevents recursive checks and makes shacl tests *much* faster.